### PR TITLE
MOS-30308 added jws to crypto core and depricated from JWS validation

### DIFF
--- a/kernel/kernel-core/src/main/java/io/mosip/kernel/core/crypto/spi/JwsSpec.java
+++ b/kernel/kernel-core/src/main/java/io/mosip/kernel/core/crypto/spi/JwsSpec.java
@@ -10,12 +10,16 @@ package io.mosip.kernel.core.crypto.spi;
  * @author Rajath
  * 
  * @since 1.0.0
+ * 
+ * @deprecated(This class is deprecated from version 1.0.5, Please use {@link CryptoCoreSpec#sign(Object, Object)} and
+ * {@link CryptoCoreSpec#verifySignature(Object, Object, Object)} instead of these methods,)
  *
  * @param <R> the return type of data
  * @param <D> the type of input data
  * @param <C> the type of Certificate key
  * @param <P> the type of private key
  */
+@Deprecated
 public interface JwsSpec<R, D, C, P> {
 	
 	/**

--- a/kernel/kernel-crypto-jce/src/main/java/io/mosip/kernel/crypto/jce/util/JWSValidation.java
+++ b/kernel/kernel-crypto-jce/src/main/java/io/mosip/kernel/crypto/jce/util/JWSValidation.java
@@ -1,18 +1,10 @@
 package io.mosip.kernel.crypto.jce.util;
 
-import java.security.InvalidKeyException;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
 import org.jose4j.jws.AlgorithmIdentifiers;
@@ -20,14 +12,18 @@ import org.jose4j.jws.JsonWebSignature;
 import org.jose4j.lang.JoseException;
 import org.springframework.stereotype.Component;
 
+import io.mosip.kernel.core.crypto.spi.CryptoCoreSpec;
 import io.mosip.kernel.core.crypto.spi.JwsSpec;
-import io.mosip.kernel.core.util.HMACUtils;
 
 /**
  * 
  * @author M1037717 This class will verify and sign the JWT
+ * 
+ * @deprecated(This class is deprecated from version 1.0.5, Please use {@link CryptoCoreSpec#sign(Object, Object)} and
+ * {@link CryptoCoreSpec#verifySignature(Object, Object, Object)} instead of these methods)
  *
  */
+@Deprecated
 @Component
 public class JWSValidation implements JwsSpec<String, String, X509Certificate,PrivateKey> {
 

--- a/kernel/kernel-crypto-jce/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreNoSuchAlgorithmExceptionTest.java
+++ b/kernel/kernel-crypto-jce/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreNoSuchAlgorithmExceptionTest.java
@@ -1,6 +1,5 @@
 package io.mosip.kernel.crypto.jce.test;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertThat;
 
@@ -105,13 +104,4 @@ public class CryptoCoreNoSuchAlgorithmExceptionTest {
 		assertThat(cryptoCore.hash(data, keyBytes), isA(String.class));
 	}
 	
-	@Test(expected = NoSuchAlgorithmException.class)
-	public void testSignNoSuchAlgorithmException() throws NoSuchAlgorithmException, InvalidKeySpecException {
-		assertThat(cryptoCore.sign(data,rsaPair.getPrivate()), isA(String.class));
-	}
-	
-	@Test(expected = NoSuchAlgorithmException.class)
-	public void testVerifyNoSuchAlgorithmException() throws NoSuchAlgorithmException, InvalidKeySpecException {
-		assertThat(cryptoCore.verifySignature(data, "InvalidSignature", rsaPair.getPublic()), is(true));
-	}
 }

--- a/kernel/kernel-crypto-jce/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreTest.java
+++ b/kernel/kernel-crypto-jce/src/test/java/io/mosip/kernel/crypto/jce/test/CryptoCoreTest.java
@@ -120,7 +120,7 @@ public class CryptoCoreTest {
 		assertThat(cryptoCore.sign(data,rsaPair.getPrivate()), isA(String.class));
 	}
 	
-	@Test(expected = InvalidKeyException.class)
+	@Test(expected = SignatureException.class)
 	public void testSignInvalidKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
 		KeyPairGenerator generator = KeyPairGenerator.getInstance("DSA");
 		generator.initialize(2048, random);
@@ -144,7 +144,7 @@ public class CryptoCoreTest {
 		assertThat(cryptoCore.verifySignature(data, null, rsaPair.getPublic()), is(true));
 	}
 	
-	@Test(expected = InvalidKeyException.class)
+	@Test(expected = SignatureException.class)
 	public void testVerifyInvalidKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
 		KeyPairGenerator generator = KeyPairGenerator.getInstance("DSA");
 		generator.initialize(2048, random);


### PR DESCRIPTION
1. Using JWS for signing
2. Deprecate the JWSValidation class for further use by other module