### PR TITLE
proxy token with none algo added

### DIFF
--- a/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/service/impl/OTPServiceImpl.java
+++ b/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/service/impl/OTPServiceImpl.java
@@ -8,13 +8,14 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
@@ -62,7 +63,8 @@ import io.mosip.kernel.core.http.ResponseWrapper;
  * @author Ramadurai Pandian
  *
  */
-@Component
+@Profile("!local")
+@Service
 public class OTPServiceImpl implements OTPService {
 
 	/*
@@ -78,15 +80,11 @@ public class OTPServiceImpl implements OTPService {
 	@Autowired
 	MosipEnvironment mosipEnvironment;
 
-
 	@Autowired
 	OTPGenerateService oTPGenerateService;
 
 	@Autowired
 	private ObjectMapper mapper;
-
-	@Autowired
-	private TokenGenerationService tokenService;
 
 	@Autowired
 	private TemplateUtil templateUtil;
@@ -129,15 +127,6 @@ public class OTPServiceImpl implements OTPService {
 
 	@Value("${mosip.kernel.prereg.realm-id}")
 	private String preregRealmId;
-
-	@Value("${spring.profiles.active}")
-	String activeProfile;
-
-	@Value("${auth.local.exp:1000000}")
-	long localExp;
-	
-	@Autowired
-	private ProxyTokenGenerator proxyTokenGenerator;
 
 	@Override
 	public AuthNResponseDto sendOTP(MosipUserDto mosipUserDto, List<String> otpChannel, String appId) {
@@ -377,17 +366,8 @@ public class OTPServiceImpl implements OTPService {
 		AccessTokenResponse responseAccessTokenResponse = null;
 		String realm = appId.equalsIgnoreCase("preregistration") ? appId : realmId;
 		try {
-			if (activeProfile.equalsIgnoreCase("local")) {
-	             accessTokenResponse = new AccessTokenResponse();
-	             long exp=System.currentTimeMillis()+localExp;
-	             token = proxyTokenGenerator.getProxyToken("AUTH", exp);
-	             accessTokenResponse.setAccess_token(token);
-	             accessTokenResponse.setExpires_in(exp+"");
-				} else {
-					accessTokenResponse = getAuthAccessToken(authClientID, authSecret, realm);
-					token = accessTokenResponse.getAccess_token();
-				}
-		
+			accessTokenResponse = getAuthAccessToken(authClientID, authSecret, realm);
+			token = accessTokenResponse.getAccess_token();
 		} catch (Exception e) {
 			throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage(), e);
 		}
@@ -405,17 +385,7 @@ public class OTPServiceImpl implements OTPService {
 			if (!validationErrorsList.isEmpty()) {
 				throw new AuthManagerServiceException(validationErrorsList);
 			}
-			
-			if (activeProfile.equalsIgnoreCase("local")) {
-				responseAccessTokenResponse = new AccessTokenResponse();
-	             long exp=System.currentTimeMillis()+localExp;
-	             responseAccessTokenResponse = new AccessTokenResponse();
-	             responseAccessTokenResponse.setAccess_token(proxyTokenGenerator.getProxyToken(mosipUser.getUserId(), exp));
-			     responseAccessTokenResponse.setRefresh_token(proxyTokenGenerator.getProxyToken(mosipUser.getUserId(), exp));
-	             responseAccessTokenResponse.setExpires_in(exp+"");	
-			} else {
-					responseAccessTokenResponse = getUserAccessToken(mosipUser.getUserId(), realm);
-				}
+			responseAccessTokenResponse = getUserAccessToken(mosipUser.getUserId(), realm);
 			OtpValidatorResponseDto otpResponse = null;
 			ResponseWrapper<?> responseObject;
 			try {
@@ -528,14 +498,7 @@ public class OTPServiceImpl implements OTPService {
 		AccessTokenResponse accessTokenResponse = null;
 		authOtpValidator.validateOTPUser(otpUser);
 		try {
-			if (activeProfile.equalsIgnoreCase("local")) {
-             accessTokenResponse = new AccessTokenResponse();
-             long exp=System.currentTimeMillis()+localExp;
-             accessTokenResponse.setAccess_token(proxyTokenGenerator.getProxyToken("AUTH", exp));
-             accessTokenResponse.setExpires_in(exp+"");
-			} else {
-				accessTokenResponse = getAuthAccessToken(authClientID, authSecret, otpUser.getAppId());
-			}
+			accessTokenResponse = getAuthAccessToken(authClientID, authSecret, otpUser.getAppId());
 		} catch (HttpClientErrorException | HttpServerErrorException ex) {
 			List<ServiceError> validationErrorsList = ExceptionUtils.getServiceErrorList(ex.getResponseBodyAsString());
 

--- a/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/service/impl/ProxyAuthServiceImpl.java
+++ b/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/service/impl/ProxyAuthServiceImpl.java
@@ -1,9 +1,6 @@
 package io.mosip.kernel.auth.service.impl;
 
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,44 +8,24 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.authentication.AuthenticationServiceException;
-import org.springframework.security.web.authentication.www.NonceExpiredException;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.mosip.kernel.auth.config.MosipEnvironment;
 import io.mosip.kernel.auth.constant.AuthConstant;
 import io.mosip.kernel.auth.constant.AuthErrorCode;
-import io.mosip.kernel.auth.constant.KeycloakConstants;
-import io.mosip.kernel.auth.dto.AccessTokenResponse;
 import io.mosip.kernel.auth.dto.AccessTokenResponseDTO;
 import io.mosip.kernel.auth.dto.AuthNResponse;
 import io.mosip.kernel.auth.dto.AuthNResponseDto;
 import io.mosip.kernel.auth.dto.AuthResponseDto;
-import io.mosip.kernel.auth.dto.AuthToken;
 import io.mosip.kernel.auth.dto.AuthZResponseDto;
 import io.mosip.kernel.auth.dto.ClientSecret;
-import io.mosip.kernel.auth.dto.KeycloakErrorResponseDto;
 import io.mosip.kernel.auth.dto.LoginUser;
 import io.mosip.kernel.auth.dto.MosipUserDto;
 import io.mosip.kernel.auth.dto.MosipUserListDto;
@@ -56,9 +33,7 @@ import io.mosip.kernel.auth.dto.MosipUserSaltListDto;
 import io.mosip.kernel.auth.dto.MosipUserTokenDto;
 import io.mosip.kernel.auth.dto.PasswordDto;
 import io.mosip.kernel.auth.dto.RIdDto;
-import io.mosip.kernel.auth.dto.RealmAccessDto;
 import io.mosip.kernel.auth.dto.RolesListDto;
-import io.mosip.kernel.auth.dto.TimeToken;
 import io.mosip.kernel.auth.dto.UserDetailsResponseDto;
 import io.mosip.kernel.auth.dto.UserNameDto;
 import io.mosip.kernel.auth.dto.UserOtp;
@@ -69,7 +44,6 @@ import io.mosip.kernel.auth.dto.UserRoleDto;
 import io.mosip.kernel.auth.dto.ValidationResponseDto;
 import io.mosip.kernel.auth.dto.otp.OtpUser;
 import io.mosip.kernel.auth.exception.AuthManagerException;
-import io.mosip.kernel.auth.exception.LoginException;
 import io.mosip.kernel.auth.repository.UserStoreFactory;
 import io.mosip.kernel.auth.repository.impl.KeycloakImpl;
 import io.mosip.kernel.auth.service.AuthService;
@@ -79,10 +53,9 @@ import io.mosip.kernel.auth.service.UinService;
 import io.mosip.kernel.auth.util.ProxyTokenGenerator;
 import io.mosip.kernel.auth.util.TokenGenerator;
 import io.mosip.kernel.auth.util.TokenValidator;
-import io.mosip.kernel.core.util.EmptyCheckUtils;
 
 /**
- * Auth Service for Authentication and Authorization
+ * Proxy Implementation of Auth service which will not use IAM just give back proxy token.
  * 
  * @author Ramadurai Pandian
  * @author Urvil Joshi
@@ -93,6 +66,8 @@ import io.mosip.kernel.core.util.EmptyCheckUtils;
 @Service
 public class ProxyAuthServiceImpl implements AuthService {
 
+	private static final Logger logger = LoggerFactory.getLogger(ProxyAuthServiceImpl.class);
+	
 	private static final String CLIENTID_AND_TOKEN_COMBINATION_HAD_BEEN_VALIDATED_SUCCESSFULLY = "Clientid and Token combination had been validated successfully";
 
 	private static final String LOG_OUT_FAILED = "log out failed";
@@ -139,8 +114,6 @@ public class ProxyAuthServiceImpl implements AuthService {
 	@Autowired
 	ObjectMapper objectmapper;
 
-	@Autowired
-	private RestTemplate restTemplate;
 
 	@Value("${mosip.kernel.open-id-url}")
 	private String openIdUrl;
@@ -196,19 +169,10 @@ public class ProxyAuthServiceImpl implements AuthService {
 	 * 
 	 */
 
+	@Deprecated
 	@Override
 	public MosipUserTokenDto validateToken(String token) throws Exception {
-		MosipUserTokenDto mosipUserDtoToken = tokenValidator.validateToken(token);
-		AuthToken authToken = customTokenServices.getTokenDetails(token);
-		if (authToken == null) {
-			throw new AuthManagerException(AuthErrorCode.INVALID_TOKEN.getErrorCode(),
-					AuthErrorCode.INVALID_TOKEN.getErrorMessage());
-		}
-		if (mosipUserDtoToken != null /* && (currentTime < authToken.getExpirationTime()) */) {
-			return mosipUserDtoToken;
-		} else {
-			throw new NonceExpiredException(AuthConstant.AUTH_TOKEN_EXPIRED_MESSAGE);
-		}
+		throw new UnsupportedOperationException("This openeration is not supported");
 	}
 
 	/**
@@ -283,7 +247,7 @@ public class ProxyAuthServiceImpl implements AuthService {
 		AuthNResponseDto authNResponseDto = new AuthNResponseDto();
 		MosipUserTokenDto mosipToken = null;
 		MosipUserDto mosipUser = null;
-		String realm = realmId;
+		String realm = null;
 		if (userOtp.getAppId().equalsIgnoreCase(AuthConstant.PRE_REGISTRATION)) {
 			realm = userOtp.getAppId();
 		}
@@ -332,6 +296,7 @@ public class ProxyAuthServiceImpl implements AuthService {
 	private AuthNResponseDto proxyTokenForLocalEnv(String subject, String status, String message) {
 		long exp = System.currentTimeMillis() + localExp;
 		String token = proxyTokenGenarator.getProxyToken(subject, exp);
+		logger.debug("token craeted for subject {} to expire at {}",subject,exp);
 		AuthNResponseDto authNResponseDto = new AuthNResponseDto();
 		authNResponseDto.setToken(token);
 		authNResponseDto.setRefreshToken(null);
@@ -354,25 +319,7 @@ public class ProxyAuthServiceImpl implements AuthService {
 
 	@Override
 	public MosipUserTokenDto retryToken(String existingToken) throws Exception {
-		MosipUserTokenDto mosipUserDtoToken = null;
-		boolean checkRefreshToken = false;
-		AuthToken accessToken = customTokenServices.getTokenDetails(existingToken);
-		if (accessToken != null) {
-			if (accessToken.getRefreshToken() != null) {
-				checkRefreshToken = tokenValidator.validateExpiry(accessToken.getRefreshToken());
-			}
-			if (checkRefreshToken) {
-				TimeToken newAccessToken = tokenGenerator.generateNewToken(accessToken.getRefreshToken());
-				AuthToken updatedAccessToken = customTokenServices.getUpdatedAccessToken(accessToken.getUserId(),
-						newAccessToken, accessToken.getUserId());
-				mosipUserDtoToken = tokenValidator.validateToken(updatedAccessToken.getAccessToken());
-			} else {
-				throw new RuntimeException("Refresh Token Expired");
-			}
-		} else {
-			throw new RuntimeException("Token doesn't exist");
-		}
-		return mosipUserDtoToken;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	/**
@@ -388,98 +335,83 @@ public class ProxyAuthServiceImpl implements AuthService {
 
 	@Override
 	public AuthNResponse invalidateToken(String token) throws Exception {
-		AuthNResponse authNResponse = null;
-		customTokenServices.revokeToken(token);
-		authNResponse = new AuthNResponse();
-		authNResponse.setStatus(AuthConstant.SUCCESS_STATUS);
-		authNResponse.setMessage(AuthConstant.TOKEN_INVALID_MESSAGE);
-		return authNResponse;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public RolesListDto getAllRoles(String appId) {
-		RolesListDto rolesListDto = keycloakImpl.getAllRoles();
-		return rolesListDto;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public MosipUserListDto getListOfUsersDetails(List<String> userDetails, String appId) throws Exception {
-		MosipUserListDto mosipUserListDto = keycloakImpl.getListOfUsersDetails(userDetails);
-		return mosipUserListDto;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public MosipUserSaltListDto getAllUserDetailsWithSalt(List<String> userDetails, String appId) throws Exception {
-		return keycloakImpl.getAllUserDetailsWithSalt(userDetails);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public RIdDto getRidBasedOnUid(String userId, String appId) throws Exception {
-		return keycloakImpl.getRidFromUserId(userId);
-
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public AuthZResponseDto unBlockUser(String userId, String appId) throws Exception {
-		return userStoreFactory.getDataStoreBasedOnApp(appId).unBlockAccount(userId);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public AuthZResponseDto changePassword(String appId, PasswordDto passwordDto) throws Exception {
-		return userStoreFactory.getDataStoreBasedOnApp(appId).changePassword(passwordDto);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public AuthZResponseDto resetPassword(String appId, PasswordDto passwordDto) throws Exception {
-		return userStoreFactory.getDataStoreBasedOnApp(appId).resetPassword(passwordDto);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public UserNameDto getUserNameBasedOnMobileNumber(String appId, String mobileNumber) throws Exception {
-		return userStoreFactory.getDataStoreBasedOnApp("registrationclient")
-				.getUserNameBasedOnMobileNumber(mobileNumber);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 
 	}
 
 	@Override
 	public MosipUserDto registerUser(UserRegistrationRequestDto userCreationRequestDto) {
-		return keycloakImpl.registerUser(userCreationRequestDto);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public UserPasswordResponseDto addUserPassword(UserPasswordRequestDto userPasswordRequestDto) {
-		return userStoreFactory.getDataStoreBasedOnApp(userPasswordRequestDto.getAppId())
-				.addPassword(userPasswordRequestDto);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public UserRoleDto getUserRole(String appId, String userId) throws Exception {
-		MosipUserDto mosipuser = null;
-		mosipuser = userStoreFactory.getDataStoreBasedOnApp(appId).getUserRoleByUserId(userId);
-		UserRoleDto userRole = new UserRoleDto();
-		userRole.setUserId(mosipuser.getUserId());
-		userRole.setRole(mosipuser.getRole());
-		return userRole;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public MosipUserDto getUserDetailBasedonMobileNumber(String appId, String mobileNumber) throws Exception {
-
-		return userStoreFactory.getDataStoreBasedOnApp(appId).getUserDetailBasedonMobileNumber(mobileNumber);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public ValidationResponseDto validateUserName(String appId, String userName) {
-		return userStoreFactory.getDataStoreBasedOnApp(appId).validateUserName(userName);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public UserDetailsResponseDto getUserDetailBasedOnUserId(String appId, List<String> userIds) {
-		return userStoreFactory.getDataStoreBasedOnApp(appId).getUserDetailBasedOnUid(userIds);
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public MosipUserDto valdiateToken(String token) {
+		//this will verify token
 		DecodedJWT decodedJWT = JWT.require(Algorithm.none()).build().verify(token);
 		MosipUserDto mosipUserDto = new MosipUserDto();
 		String user = decodedJWT.getSubject();
@@ -492,8 +424,6 @@ public class ProxyAuthServiceImpl implements AuthService {
 		return mosipUserDto;
 	}
 
-	Logger logger = LoggerFactory.getLogger(this.getClass().getName());
-
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -501,148 +431,20 @@ public class ProxyAuthServiceImpl implements AuthService {
 	 */
 	@Override
 	public AuthResponseDto logoutUser(String token) {
-		if (EmptyCheckUtils.isNullEmpty(token)) {
-			throw new AuthenticationServiceException(AuthErrorCode.INVALID_TOKEN.getErrorMessage());
-		}
-		Map<String, String> pathparams = new HashMap<>();
-		pathparams.put(KeycloakConstants.REALM_ID, realmID);
-		ResponseEntity<String> response = null;
-		AuthResponseDto authResponseDto = new AuthResponseDto();
-		StringBuilder urlBuilder = new StringBuilder().append(openIdUrl).append("logout");
-		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(urlBuilder.toString())
-				.queryParam(KeycloakConstants.ID_TOKEN_HINT, token);
-		try {
-			response = restTemplate.getForEntity(uriComponentsBuilder.buildAndExpand(pathparams).toUriString(),
-					String.class);
-			System.out.println(response.getBody());
-		} catch (HttpClientErrorException | HttpServerErrorException e) {
-			throw new AuthManagerException(AuthErrorCode.REST_EXCEPTION.getErrorCode(),
-					AuthErrorCode.REST_EXCEPTION.getErrorMessage() + e.getResponseBodyAsString());
-		}
-
-		if (response.getStatusCode().is2xxSuccessful()) {
-			authResponseDto.setMessage(SUCCESSFULLY_LOGGED_OUT);
-			authResponseDto.setStatus(SUCCESS);
-		} else {
-			authResponseDto.setMessage(LOG_OUT_FAILED);
-			authResponseDto.setStatus(FAILED);
-		}
-		return authResponseDto;
-	}
-
-	private MosipUserDto getClaims(String cookie) {
-		DecodedJWT decodedJWT = JWT.decode(cookie);
-
-		Claim realmAccess = decodedJWT.getClaim(AuthConstant.REALM_ACCESS);
-
-		RealmAccessDto access = realmAccess.as(RealmAccessDto.class);
-		String[] roles = access.getRoles();
-		StringBuilder builder = new StringBuilder();
-
-		for (String r : roles) {
-			builder.append(r);
-			builder.append(AuthConstant.COMMA);
-		}
-		MosipUserDto dto = new MosipUserDto();
-		dto.setUserId(decodedJWT.getClaim(AuthConstant.PREFERRED_USERNAME).asString());
-		dto.setMail(decodedJWT.getClaim(AuthConstant.EMAIL).asString());
-		dto.setMobile(decodedJWT.getClaim(AuthConstant.MOBILE).asString());
-		dto.setName(decodedJWT.getClaim(AuthConstant.PREFERRED_USERNAME).asString());
-		dto.setRId(decodedJWT.getClaim(AuthConstant.RID).asString());
-		dto.setToken(cookie);
-		dto.setRole(builder.toString());
-		return dto;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 	@Override
 	public AccessTokenResponseDTO loginRedirect(String state, String sessionState, String code, String stateCookie,
 			String redirectURI) {
-		// Compare states
-		if (!stateCookie.equals(state)) {
-			throw new AuthManagerException(AuthErrorCode.KEYCLOAK_STATE_EXCEPTION.getErrorCode(),
-					AuthErrorCode.KEYCLOAK_STATE_EXCEPTION.getErrorMessage());
-		}
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-		map.add(KeycloakConstants.GRANT_TYPE, loginFlowName);
-		map.add(KeycloakConstants.CLIENT_ID, clientID);
-		map.add(KeycloakConstants.CLIENT_SECRET, clientSecret);
-		map.add(KeycloakConstants.CODE, code);
-		map.add(KeycloakConstants.REDIRECT_URI, this.redirectURI + redirectURI);
-		Map<String, String> pathParam = new HashMap<>();
-		pathParam.put("realmId", realmID);
-		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(tokenEndpoint);
-		HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(map, headers);
-		ResponseEntity<String> responseEntity = null;
-		try {
-			responseEntity = restTemplate.exchange(uriBuilder.buildAndExpand(pathParam).toUriString(), HttpMethod.POST,
-					entity, String.class);
-
-		} catch (HttpClientErrorException | HttpServerErrorException e) {
-			KeycloakErrorResponseDto keycloakErrorResponseDto = parseKeyClockErrorResponse(e);
-			throw new LoginException(AuthErrorCode.KEYCLOAK_ACESSTOKEN_EXCEPTION.getErrorCode(),
-					AuthErrorCode.KEYCLOAK_ACESSTOKEN_EXCEPTION.getErrorMessage() + AuthConstant.WHITESPACE
-							+ keycloakErrorResponseDto.getError_description());
-		}
-		AccessTokenResponse accessTokenResponse = null;
-		try {
-			accessTokenResponse = objectmapper.readValue(responseEntity.getBody(), AccessTokenResponse.class);
-		} catch (IOException exception) {
-			throw new LoginException(AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorCode(),
-					AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorMessage() + AuthConstant.WHITESPACE
-							+ exception.getMessage());
-		}
-		AccessTokenResponseDTO accessTokenResponseDTO = new AccessTokenResponseDTO();
-		accessTokenResponseDTO.setAccessToken(accessTokenResponse.getAccess_token());
-		accessTokenResponseDTO.setExpiresIn(accessTokenResponse.getExpires_in());
-		return accessTokenResponseDTO;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
-	private KeycloakErrorResponseDto parseKeyClockErrorResponse(HttpStatusCodeException exception) {
-		KeycloakErrorResponseDto keycloakErrorResponseDto = null;
-		try {
-			keycloakErrorResponseDto = objectmapper.readValue(exception.getResponseBodyAsString(),
-					KeycloakErrorResponseDto.class);
-		} catch (IOException e) {
-			throw new LoginException(AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorCode(),
-					AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorMessage() + AuthConstant.WHITESPACE + e.getMessage());
-		}
-		return keycloakErrorResponseDto;
-	}
+
 
 	@Override
 	public String getKeycloakURI(String redirectURI, String state) {
-		Map<String, String> pathParam = new HashMap<>();
-		pathParam.put("realmId", realmID);
-		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl(authorizationEndpoint);
-		uriComponentsBuilder.queryParam(KeycloakConstants.CLIENT_ID, clientID);
-		uriComponentsBuilder.queryParam(KeycloakConstants.REDIRECT_URI, this.redirectURI + redirectURI);
-		uriComponentsBuilder.queryParam(KeycloakConstants.STATE, state);
-		uriComponentsBuilder.queryParam(KeycloakConstants.RESPONSE_TYPE, responseType);
-		uriComponentsBuilder.queryParam(KeycloakConstants.SCOPE, scope);
-
-		return uriComponentsBuilder.buildAndExpand(pathParam).toString();
-	}
-
-	private MultiValueMap<String, String> getPasswordValueMap(String clientID, String clientSecret, String username,
-			String password) {
-		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-		map.add(AuthConstant.GRANT_TYPE, AuthConstant.PASSWORDCONSTANT);
-		map.add(AuthConstant.USER_NAME, username);
-		map.add(AuthConstant.PASSWORDCONSTANT, password);
-		map.add(AuthConstant.CLIENT_ID, clientID);
-		map.add(AuthConstant.CLIENT_SECRET, clientSecret);
-		return map;
-	}
-
-	private MultiValueMap<String, String> getClientSecretValueMap(String clientID, String clientSecret) {
-		MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
-		map.add(AuthConstant.GRANT_TYPE, AuthConstant.CLIENT_CREDENTIALS);
-		map.add(AuthConstant.CLIENT_ID, clientID);
-		map.add(AuthConstant.CLIENT_SECRET, clientSecret);
-		return map;
+		throw new UnsupportedOperationException("This openeration is not supported in local profile for now");
 	}
 
 }

--- a/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/service/impl/ProxyOTPServiceImpl.java
+++ b/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/service/impl/ProxyOTPServiceImpl.java
@@ -1,0 +1,705 @@
+package io.mosip.kernel.auth.service.impl;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.mosip.kernel.auth.adapter.constant.AuthAdapterConstant;
+import io.mosip.kernel.auth.adapter.exception.AuthNException;
+import io.mosip.kernel.auth.adapter.exception.AuthZException;
+import io.mosip.kernel.auth.config.MosipEnvironment;
+import io.mosip.kernel.auth.constant.AuthConstant;
+import io.mosip.kernel.auth.constant.AuthErrorCode;
+import io.mosip.kernel.auth.dto.AccessTokenResponse;
+import io.mosip.kernel.auth.dto.AuthNResponseDto;
+import io.mosip.kernel.auth.dto.MosipUserDto;
+import io.mosip.kernel.auth.dto.MosipUserTokenDto;
+import io.mosip.kernel.auth.dto.otp.OtpEmailSendResponseDto;
+import io.mosip.kernel.auth.dto.otp.OtpGenerateRequest;
+import io.mosip.kernel.auth.dto.otp.OtpGenerateResponseDto;
+import io.mosip.kernel.auth.dto.otp.OtpSmsSendRequestDto;
+import io.mosip.kernel.auth.dto.otp.OtpTemplateDto;
+import io.mosip.kernel.auth.dto.otp.OtpTemplateResponseDto;
+import io.mosip.kernel.auth.dto.otp.OtpUser;
+import io.mosip.kernel.auth.dto.otp.OtpValidatorResponseDto;
+import io.mosip.kernel.auth.dto.otp.SmsResponseDto;
+import io.mosip.kernel.auth.dto.otp.email.OTPEmailTemplate;
+import io.mosip.kernel.auth.exception.AuthManagerException;
+import io.mosip.kernel.auth.exception.AuthManagerServiceException;
+import io.mosip.kernel.auth.service.OTPGenerateService;
+import io.mosip.kernel.auth.service.OTPService;
+import io.mosip.kernel.auth.service.TokenGenerationService;
+import io.mosip.kernel.auth.util.OtpValidator;
+import io.mosip.kernel.auth.util.ProxyTokenGenerator;
+import io.mosip.kernel.auth.util.TemplateUtil;
+import io.mosip.kernel.core.exception.ExceptionUtils;
+import io.mosip.kernel.core.exception.ServiceError;
+import io.mosip.kernel.core.http.RequestWrapper;
+import io.mosip.kernel.core.http.ResponseWrapper;
+
+/**
+ * @author Urvil Joshi
+ *
+ */
+@Profile("local")
+@Service
+public class ProxyOTPServiceImpl implements OTPService {
+
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see io.mosip.kernel.auth.service.OTPService#sendOTP(io.mosip.kernel.auth.
+	 * entities.MosipUserDto, java.lang.String)
+	 */
+
+	@Autowired
+	RestTemplate restTemplate;
+
+	@Autowired
+	MosipEnvironment mosipEnvironment;
+
+	@Autowired
+	OTPGenerateService oTPGenerateService;
+
+	@Autowired
+	private ObjectMapper mapper;
+
+	@Autowired
+	private TokenGenerationService tokenService;
+
+	@Autowired
+	private TemplateUtil templateUtil;
+
+	@Autowired
+	private OtpValidator authOtpValidator;
+
+	@Value("${mosip.kernel.open-id-url}")
+	private String keycloakOpenIdUrl;
+
+	@Value("${mosip.kernel.realm-id}")
+	private String realmId;
+
+	@Value("${mosip.kernel.auth.client.id}")
+	private String authClientID;
+
+	@Value("${mosip.kernel.prereg.client.id}")
+	private String preregClientId;
+
+	@Value("${mosip.kernel.prereg.secret.key}")
+	private String preregSecretKey;
+
+	@Value("${mosip.kernel.auth.secret.key}")
+	private String authSecret;
+
+	@Value("${mosip.kernel.ida.client.id}")
+	private String idaClientID;
+
+	@Value("${mosip.kernel.ida.secret.key}")
+	private String idaSecret;
+
+	@Value("${mosip.admin.clientid}")
+	private String mosipAdminClientID;
+
+	@Value("${mosip.admin.clientsecret}")
+	private String mosipAdminSecret;
+
+	@Value("${mosip.admin.pre-reg_user_password}")
+	private String preRegUserPassword;
+
+	@Value("${mosip.kernel.prereg.realm-id}")
+	private String preregRealmId;
+
+	@Value("${spring.profiles.active}")
+	String activeProfile;
+
+	@Value("${auth.local.exp:1000000}")
+	long localExp;
+
+	@Autowired
+	private ProxyTokenGenerator proxyTokenGenerator;
+
+	@Deprecated
+	@Override
+	public AuthNResponseDto sendOTP(MosipUserDto mosipUserDto, List<String> otpChannel, String appId) {
+		AuthNResponseDto authNResponseDto = null;
+		OtpEmailSendResponseDto otpEmailSendResponseDto = null;
+		SmsResponseDto otpSmsSendResponseDto = null;
+		String emailMessage = null, mobileMessage = null;
+		String token = null;
+		try {
+			// token = tokenService.getInternalTokenGenerationService();
+			AccessTokenResponse accessTokenResponse = getAuthAccessToken(authClientID,
+					authSecret, realmId);
+			token = AuthAdapterConstant.AUTH_ADMIN_COOKIE_PREFIX + accessTokenResponse.getAccess_token();
+		} catch (HttpClientErrorException | HttpServerErrorException ex) {
+			List<ServiceError> validationErrorsList = ExceptionUtils.getServiceErrorList(ex.getResponseBodyAsString());
+
+			if (ex.getRawStatusCode() == 401) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthNException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorCode(),
+							AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorMessage(), ex);
+				}
+			}
+			if (ex.getRawStatusCode() == 403) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthZException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorCode(),
+							AuthErrorCode.RESPONSE_PARSE_ERROR.getErrorMessage(), ex);
+				}
+			}
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			} else {
+				throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(), ex.getMessage(), ex);
+			}
+		} catch (Exception e) {
+			throw new AuthManagerException(AuthErrorCode.SERVER_ERROR.getErrorCode(), e.getMessage(), e);
+		}
+		OtpGenerateResponseDto otpGenerateResponseDto = oTPGenerateService.generateOTP(mosipUserDto, token);
+		if (otpGenerateResponseDto != null && otpGenerateResponseDto.getStatus().equals("USER_BLOCKED")) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(AuthConstant.FAILURE_STATUS);
+			authNResponseDto.setMessage(otpGenerateResponseDto.getStatus());
+			return authNResponseDto;
+		}
+		for (String channel : otpChannel) {
+			switch (channel) {
+			case AuthConstant.EMAIL:
+				emailMessage = getOtpEmailMessage(otpGenerateResponseDto, appId, token);
+				otpEmailSendResponseDto = sendOtpByEmail(emailMessage, mosipUserDto.getMail(), token);
+				break;
+			case AuthConstant.PHONE:
+				mobileMessage = getOtpSmsMessage(otpGenerateResponseDto, appId, token);
+				otpSmsSendResponseDto = sendOtpBySms(mobileMessage, mosipUserDto.getMobile(), token);
+				break;
+			}
+		}
+		if (otpEmailSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(otpEmailSendResponseDto.getStatus());
+			authNResponseDto.setMessage(otpEmailSendResponseDto.getMessage());
+		}
+		if (otpSmsSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(otpSmsSendResponseDto.getStatus());
+			authNResponseDto.setMessage(otpSmsSendResponseDto.getMessage());
+		}
+		return authNResponseDto;
+	}
+
+	private String getOtpEmailMessage(OtpGenerateResponseDto otpGenerateResponseDto, String appId, String token) {
+		String template = null;
+		OtpTemplateResponseDto otpTemplateResponseDto = null;
+
+		final String url = mosipEnvironment.getMasterDataTemplateApi() + "/" + mosipEnvironment.getPrimaryLanguage()
+				+ mosipEnvironment.getMasterDataOtpTemplate();
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(AuthConstant.COOKIE, AuthConstant.AUTH_HEADER + token);
+		ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<Object>(headers),
+				String.class);
+		if (response.getStatusCode().equals(HttpStatus.OK)) {
+			String responseBody = response.getBody();
+			List<ServiceError> validationErrorsList = null;
+			validationErrorsList = ExceptionUtils.getServiceErrorList(responseBody);
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			}
+			ResponseWrapper<?> responseObject;
+			try {
+				responseObject = mapper.readValue(response.getBody(), ResponseWrapper.class);
+				otpTemplateResponseDto = mapper.readValue(mapper.writeValueAsString(responseObject.getResponse()),
+						OtpTemplateResponseDto.class);
+			} catch (Exception e) {
+				throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage(), e);
+			}
+		}
+		List<OtpTemplateDto> otpTemplateList = otpTemplateResponseDto.getTemplates();
+		for (OtpTemplateDto otpTemplateDto : otpTemplateList) {
+			if (otpTemplateDto.getId().toLowerCase().equals(appId.toLowerCase())) {
+				template = otpTemplateDto.getFileText();
+
+			}
+		}
+		String otp = otpGenerateResponseDto.getOtp();
+		template = template.replace("$otp", otp);
+		return template;
+	}
+
+	private String getOtpSmsMessage(OtpGenerateResponseDto otpGenerateResponseDto, String appId, String token) {
+		try {
+			final String url = mosipEnvironment.getMasterDataTemplateApi() + "/" + mosipEnvironment.getPrimaryLanguage()
+					+ mosipEnvironment.getMasterDataOtpTemplate();
+			OtpTemplateResponseDto otpTemplateResponseDto = null;
+			HttpHeaders headers = new HttpHeaders();
+			headers.set(AuthConstant.COOKIE, AuthConstant.AUTH_HEADER + token);
+			ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET,
+					new HttpEntity<Object>(headers), String.class);
+			if (response.getStatusCode().equals(HttpStatus.OK)) {
+				String responseBody = response.getBody();
+				List<ServiceError> validationErrorsList = null;
+				validationErrorsList = ExceptionUtils.getServiceErrorList(responseBody);
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthManagerServiceException(validationErrorsList);
+				}
+				ResponseWrapper<?> responseObject;
+				try {
+					responseObject = mapper.readValue(response.getBody(), ResponseWrapper.class);
+					otpTemplateResponseDto = mapper.readValue(mapper.writeValueAsString(responseObject.getResponse()),
+							OtpTemplateResponseDto.class);
+				} catch (Exception e) {
+					throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage(), e);
+				}
+			}
+			String template = null;
+			List<OtpTemplateDto> otpTemplateList = otpTemplateResponseDto.getTemplates();
+			for (OtpTemplateDto otpTemplateDto : otpTemplateList) {
+				if (otpTemplateDto.getId().toLowerCase().equals(appId.toLowerCase())) {
+					template = otpTemplateDto.getFileText();
+
+				}
+			}
+			String otp = otpGenerateResponseDto.getOtp();
+			template = template.replace("$otp", otp);
+			return template;
+		} catch (HttpClientErrorException | HttpServerErrorException e) {
+			String message = e.getResponseBodyAsString();
+			throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), message);
+		}
+	}
+
+	private OtpEmailSendResponseDto sendOtpByEmail(String message, String email, String token) {
+		ResponseEntity<String> response = null;
+		String url = mosipEnvironment.getOtpSenderEmailApi();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+		headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON_UTF8));
+		OtpEmailSendResponseDto otpEmailSendResponseDto = null;
+		headers.set(AuthConstant.COOKIE, AuthConstant.AUTH_HEADER + token);
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
+		map.add("mailTo", email);
+		map.add("mailSubject", "MOSIP Notification");
+		map.add("mailContent", message);
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(map, headers);
+		try {
+			try {
+				response = restTemplate.exchange(url, HttpMethod.POST, request, String.class);
+			} catch (HttpServerErrorException | HttpClientErrorException e) {
+				String error = e.getResponseBodyAsString();
+			} catch (RestClientException e) {
+				e.printStackTrace();
+			}
+		} catch (HttpServerErrorException | HttpClientErrorException e) {
+			String error = e.getResponseBodyAsString();
+		}
+
+		if (response.getStatusCode().equals(HttpStatus.OK)) {
+			String responseBody = response.getBody();
+			List<ServiceError> validationErrorsList = null;
+			validationErrorsList = ExceptionUtils.getServiceErrorList(responseBody);
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			}
+			ResponseWrapper<?> responseObject;
+			try {
+				responseObject = mapper.readValue(response.getBody(), ResponseWrapper.class);
+				otpEmailSendResponseDto = mapper.readValue(mapper.writeValueAsString(responseObject.getResponse()),
+						OtpEmailSendResponseDto.class);
+			} catch (Exception e) {
+				throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage(), e);
+			}
+		}
+		return otpEmailSendResponseDto;
+	}
+
+	private SmsResponseDto sendOtpBySms(String message, String mobile, String token) {
+		try {
+			List<ServiceError> validationErrorsList = null;
+			OtpSmsSendRequestDto otpSmsSendRequestDto = new OtpSmsSendRequestDto(mobile, message);
+			SmsResponseDto otpSmsSendResponseDto = null;
+			String url = mosipEnvironment.getOtpSenderSmsApi();
+			RequestWrapper<OtpSmsSendRequestDto> reqWrapper = new RequestWrapper<>();
+			reqWrapper.setRequesttime(LocalDateTime.now());
+			reqWrapper.setRequest(otpSmsSendRequestDto);
+			HttpHeaders headers = new HttpHeaders();
+			headers.set(AuthConstant.COOKIE, AuthConstant.AUTH_HEADER + token);
+			ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST,
+					new HttpEntity<Object>(reqWrapper, headers), String.class);
+			validationErrorsList = ExceptionUtils.getServiceErrorList(response.getBody());
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			}
+			ResponseWrapper<?> responseObject;
+			try {
+				responseObject = mapper.readValue(response.getBody(), ResponseWrapper.class);
+				otpSmsSendResponseDto = mapper.readValue(mapper.writeValueAsString(responseObject.getResponse()),
+						SmsResponseDto.class);
+			} catch (Exception e) {
+				throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage());
+			}
+			return otpSmsSendResponseDto;
+		} catch (HttpClientErrorException | HttpServerErrorException e) {
+			String errmessage = e.getResponseBodyAsString();
+			throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), errmessage);
+		}
+	}
+
+	@Override
+	public MosipUserTokenDto validateOTP(MosipUserDto mosipUser, String otp, String appId) {
+		String key = new OtpGenerateRequest(mosipUser).getKey();
+		MosipUserTokenDto mosipUserDtoToken = null;
+		ResponseEntity<String> response = null;
+		final String url = mosipEnvironment.getVerifyOtpUserApi();
+		String token = null;
+		AccessTokenResponse accessTokenResponse = null;
+		AccessTokenResponse responseAccessTokenResponse = null;
+		String realm = appId.equalsIgnoreCase("preregistration") ? appId : realmId;
+		try {
+			accessTokenResponse = new AccessTokenResponse();
+			long exp = System.currentTimeMillis() + localExp;
+			token = proxyTokenGenerator.getProxyToken("AUTH", exp);
+			accessTokenResponse.setAccess_token(token);
+			accessTokenResponse.setExpires_in(exp + "");
+
+		} catch (Exception e) {
+			throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage(), e);
+		}
+		UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url).queryParam("key", key).queryParam("otp",
+				otp);
+		HttpHeaders headers = new HttpHeaders();
+		headers.set(AuthConstant.COOKIE, AuthConstant.AUTH_HEADER + token);
+		response = restTemplate.exchange(builder.toUriString(), HttpMethod.GET, new HttpEntity<Object>(headers),
+				String.class);
+		if (response.getStatusCode().equals(HttpStatus.OK)) {
+			String responseBody = response.getBody();
+			List<ServiceError> validationErrorsList = null;
+			validationErrorsList = ExceptionUtils.getServiceErrorList(responseBody);
+
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			}
+			responseAccessTokenResponse = new AccessTokenResponse();
+			long exp = System.currentTimeMillis() + localExp;
+			responseAccessTokenResponse = new AccessTokenResponse();
+			responseAccessTokenResponse.setAccess_token(proxyTokenGenerator.getProxyToken(mosipUser.getUserId(), exp));
+			responseAccessTokenResponse.setRefresh_token(proxyTokenGenerator.getProxyToken(mosipUser.getUserId(), exp));
+			responseAccessTokenResponse.setExpires_in(exp + "");
+			OtpValidatorResponseDto otpResponse = null;
+			ResponseWrapper<?> responseObject;
+			try {
+				responseObject = mapper.readValue(response.getBody(), ResponseWrapper.class);
+				otpResponse = mapper.readValue(mapper.writeValueAsString(responseObject.getResponse()),
+						OtpValidatorResponseDto.class);
+			} catch (Exception e) {
+				throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage(), e);
+			}
+			if (otpResponse.getStatus() != null && otpResponse.getStatus().equals("success")) {
+				String expTime = accessTokenResponse.getExpires_in();
+				mosipUserDtoToken = new MosipUserTokenDto(mosipUser, responseAccessTokenResponse.getAccess_token(),
+						responseAccessTokenResponse.getRefresh_token(), Long.parseLong(expTime), null, null);
+				mosipUserDtoToken.setMessage(otpResponse.getMessage());
+				mosipUserDtoToken.setStatus(otpResponse.getStatus());
+			} else {
+				mosipUserDtoToken = new MosipUserTokenDto();
+				mosipUserDtoToken.setMessage(otpResponse.getMessage());
+				mosipUserDtoToken.setStatus(otpResponse.getStatus());
+			}
+
+		}
+		return mosipUserDtoToken;
+	}
+
+	@Override
+	public AuthNResponseDto sendOTPForUin(MosipUserDto mosipUser, OtpUser otpUser, String appId) {
+		AuthNResponseDto authNResponseDto = null;
+		OtpEmailSendResponseDto otpEmailSendResponseDto = null;
+		SmsResponseDto otpSmsSendResponseDto = null;
+		String mobileMessage = null;
+		OTPEmailTemplate emailTemplate = null;
+		AccessTokenResponse accessTokenResponse = null;
+		authOtpValidator.validateOTPUser(otpUser);
+		try {
+			// token = tokenService.getInternalTokenGenerationService();
+			accessTokenResponse = getAuthAccessToken(idaClientID, idaSecret, realmId);
+		} catch (HttpClientErrorException | HttpServerErrorException ex) {
+			List<ServiceError> validationErrorsList = ExceptionUtils.getServiceErrorList(ex.getResponseBodyAsString());
+
+			if (ex.getRawStatusCode() == 401) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthNException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(),
+							AuthErrorCode.CLIENT_ERROR.getErrorMessage(), ex);
+				}
+			}
+			if (ex.getRawStatusCode() == 403) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthZException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(), ex.getMessage(), ex);
+				}
+			}
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			} else {
+				throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(), ex.getMessage(), ex);
+			}
+		}
+		OtpGenerateResponseDto otpGenerateResponseDto = oTPGenerateService.generateOTP(mosipUser,
+				accessTokenResponse.getAccess_token());
+		if (otpGenerateResponseDto != null && otpGenerateResponseDto.getStatus().equals("USER_BLOCKED")) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(AuthConstant.FAILURE_STATUS);
+			authNResponseDto.setMessage(otpGenerateResponseDto.getStatus());
+			return authNResponseDto;
+		}
+		for (String channel : otpUser.getOtpChannel()) {
+			switch (channel.toLowerCase()) {
+			case AuthConstant.EMAIL:
+				emailTemplate = templateUtil.getEmailTemplate(otpGenerateResponseDto.getOtp(), otpUser,
+						accessTokenResponse.getAccess_token());
+				otpEmailSendResponseDto = sendOtpByEmail(emailTemplate, mosipUser.getMail(),
+						accessTokenResponse.getAccess_token());
+				break;
+			case AuthConstant.PHONE:
+				mobileMessage = templateUtil.getOtpSmsMessage(otpGenerateResponseDto.getOtp(), otpUser,
+						accessTokenResponse.getAccess_token());
+				otpSmsSendResponseDto = sendOtpBySms(mobileMessage, mosipUser.getMobile(),
+						accessTokenResponse.getAccess_token());
+				break;
+			}
+		}
+
+		if (otpEmailSendResponseDto != null && otpSmsSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(AuthConstant.SUCCESS_STATUS);
+			authNResponseDto.setMessage(AuthConstant.ALL_CHANNELS_MESSAGE);
+		} else if (otpEmailSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(otpEmailSendResponseDto.getStatus());
+			authNResponseDto.setMessage(otpEmailSendResponseDto.getMessage());
+		} else if (otpSmsSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(otpSmsSendResponseDto.getStatus());
+			authNResponseDto.setMessage(otpSmsSendResponseDto.getMessage());
+		}
+		return authNResponseDto;
+	}
+
+	@Override
+	public AuthNResponseDto sendOTP(MosipUserDto mosipUser, OtpUser otpUser) throws Exception {
+		AuthNResponseDto authNResponseDto = null;
+		OtpEmailSendResponseDto otpEmailSendResponseDto = null;
+		SmsResponseDto otpSmsSendResponseDto = null;
+		String mobileMessage = null;
+		OTPEmailTemplate emailTemplate = null;
+		AccessTokenResponse accessTokenResponse = null;
+		authOtpValidator.validateOTPUser(otpUser);
+		try {
+			accessTokenResponse = new AccessTokenResponse();
+			long exp = System.currentTimeMillis() + localExp;
+			accessTokenResponse.setAccess_token(proxyTokenGenerator.getProxyToken("AUTH", exp));
+			accessTokenResponse.setExpires_in(exp + "");
+		} catch (HttpClientErrorException | HttpServerErrorException ex) {
+			List<ServiceError> validationErrorsList = ExceptionUtils.getServiceErrorList(ex.getResponseBodyAsString());
+
+			if (ex.getRawStatusCode() == 401) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthNException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(),
+							AuthErrorCode.CLIENT_ERROR.getErrorMessage(), ex);
+				}
+			}
+			if (ex.getRawStatusCode() == 403) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthZException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(), ex.getMessage(), ex);
+				}
+			}
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			} else {
+				throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(), ex.getMessage(), ex);
+			}
+		}
+		OtpGenerateResponseDto otpGenerateResponseDto = oTPGenerateService.generateOTP(mosipUser,
+				accessTokenResponse.getAccess_token());
+		if (otpGenerateResponseDto != null && otpGenerateResponseDto.getStatus().equals("USER_BLOCKED")) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(AuthConstant.FAILURE_STATUS);
+			authNResponseDto.setMessage(otpGenerateResponseDto.getStatus());
+			return authNResponseDto;
+		}
+		for (String channel : otpUser.getOtpChannel()) {
+			switch (channel.toLowerCase()) {
+			case AuthConstant.EMAIL:
+				emailTemplate = templateUtil.getEmailTemplate(otpGenerateResponseDto.getOtp(), otpUser,
+						accessTokenResponse.getAccess_token());
+				otpEmailSendResponseDto = sendOtpByEmail(emailTemplate, mosipUser.getUserId(),
+						accessTokenResponse.getAccess_token());
+				break;
+			case AuthConstant.PHONE:
+				mobileMessage = templateUtil.getOtpSmsMessage(otpGenerateResponseDto.getOtp(), otpUser,
+						accessTokenResponse.getAccess_token());
+				otpSmsSendResponseDto = sendOtpBySms(mobileMessage, mosipUser.getUserId(),
+						accessTokenResponse.getAccess_token());
+				break;
+			}
+		}
+
+		if (otpEmailSendResponseDto != null && otpSmsSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(AuthConstant.SUCCESS_STATUS);
+			authNResponseDto.setMessage(AuthConstant.ALL_CHANNELS_MESSAGE);
+		} else if (otpEmailSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(otpEmailSendResponseDto.getStatus());
+			authNResponseDto.setMessage(otpEmailSendResponseDto.getMessage());
+		} else if (otpSmsSendResponseDto != null) {
+			authNResponseDto = new AuthNResponseDto();
+			authNResponseDto.setStatus(otpSmsSendResponseDto.getStatus());
+			authNResponseDto.setMessage(otpSmsSendResponseDto.getMessage());
+		}
+		return authNResponseDto;
+	}
+
+	private OtpEmailSendResponseDto sendOtpByEmail(OTPEmailTemplate emailTemplate, String email, String token) {
+		ResponseEntity<String> response = null;
+		String url = mosipEnvironment.getOtpSenderEmailApi();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+		headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON_UTF8));
+		OtpEmailSendResponseDto otpEmailSendResponseDto = null;
+		headers.set(AuthConstant.COOKIE, AuthConstant.AUTH_HEADER + token);
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
+		map.add("mailTo", email);
+		map.add("mailSubject", emailTemplate.getEmailSubject());
+		map.add("mailContent", emailTemplate.getEmailContent());
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(map, headers);
+		try {
+			response = restTemplate.exchange(url, HttpMethod.POST, request, String.class);
+			if (response.getStatusCode().equals(HttpStatus.OK)) {
+				String responseBody = response.getBody();
+				List<ServiceError> validationErrorsList = null;
+				validationErrorsList = ExceptionUtils.getServiceErrorList(responseBody);
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthManagerServiceException(validationErrorsList);
+				}
+				ResponseWrapper<?> responseObject;
+				try {
+					responseObject = mapper.readValue(response.getBody(), ResponseWrapper.class);
+					otpEmailSendResponseDto = mapper.readValue(mapper.writeValueAsString(responseObject.getResponse()),
+							OtpEmailSendResponseDto.class);
+				} catch (Exception e) {
+					throw new AuthManagerException(String.valueOf(HttpStatus.UNAUTHORIZED.value()), e.getMessage(), e);
+				}
+			}
+		} catch (HttpClientErrorException | HttpServerErrorException ex) {
+			List<ServiceError> validationErrorsList = ExceptionUtils.getServiceErrorList(ex.getResponseBodyAsString());
+
+			if (ex.getRawStatusCode() == 401) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthNException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(),
+							AuthErrorCode.CLIENT_ERROR.getErrorMessage(), ex);
+				}
+			}
+			if (ex.getRawStatusCode() == 403) {
+				if (!validationErrorsList.isEmpty()) {
+					throw new AuthZException(validationErrorsList);
+				} else {
+					throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(), ex.getMessage(), ex);
+				}
+			}
+			if (!validationErrorsList.isEmpty()) {
+				throw new AuthManagerServiceException(validationErrorsList);
+			} else {
+				throw new AuthManagerException(AuthErrorCode.CLIENT_ERROR.getErrorCode(), ex.getMessage(), ex);
+			}
+		}
+		return otpEmailSendResponseDto;
+	}
+
+	private AccessTokenResponse getUserAccessToken(String username, String realm) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		MultiValueMap<String, String> tokenRequestBody = null;
+		Map<String, String> pathParams = new HashMap<>();
+		pathParams.put(AuthConstant.REALM_ID, realm);
+		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(keycloakOpenIdUrl + "/token");
+		tokenRequestBody = getAdminValueMap(username, realm);
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(tokenRequestBody, headers);
+		ResponseEntity<AccessTokenResponse> response = restTemplate.postForEntity(
+				uriComponentsBuilder.buildAndExpand(pathParams).toUriString(), request, AccessTokenResponse.class);
+		return response.getBody();
+	}
+
+	private AccessTokenResponse getAuthAccessToken(String clientID, String clientSecret, String realmId) {
+		HttpHeaders headers = new HttpHeaders();
+		if (realmId.equalsIgnoreCase(preregRealmId)) {
+			clientID = preregClientId;
+			clientSecret = preregSecretKey;
+		}
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		MultiValueMap<String, String> tokenRequestBody = null;
+		Map<String, String> pathParams = new HashMap<>();
+		pathParams.put(AuthConstant.REALM_ID, realmId);
+		UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(keycloakOpenIdUrl + "/token");
+		tokenRequestBody = getClientValueMap(clientID, clientSecret);
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(tokenRequestBody, headers);
+		ResponseEntity<AccessTokenResponse> response = restTemplate.postForEntity(
+				uriComponentsBuilder.buildAndExpand(pathParams).toUriString(), request, AccessTokenResponse.class);
+		return response.getBody();
+	}
+
+	private MultiValueMap<String, String> getAdminValueMap(String username, String realm) {
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		if (realm.equalsIgnoreCase(preregRealmId)) {
+			map.add(AuthConstant.CLIENT_ID, preregClientId);
+			map.add(AuthConstant.CLIENT_SECRET, preregSecretKey);
+		} else {
+			map.add(AuthConstant.CLIENT_ID, mosipAdminClientID);
+			map.add(AuthConstant.CLIENT_SECRET, mosipAdminSecret);
+		}
+		map.add(AuthConstant.GRANT_TYPE, AuthConstant.PASSWORDCONSTANT);
+		map.add(AuthConstant.USER_NAME, username);
+		map.add(AuthConstant.PASSWORDCONSTANT, preRegUserPassword);
+		return map;
+	}
+
+	private MultiValueMap<String, String> getClientValueMap(String clientID, String clientSecret) {
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		map.add(AuthConstant.GRANT_TYPE, AuthConstant.CLIENT_CREDENTIALS);
+		map.add(AuthConstant.CLIENT_ID, clientID);
+		map.add(AuthConstant.CLIENT_SECRET, clientSecret);
+		return map;
+	}
+}

--- a/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/util/ProxyTokenGenerator.java
+++ b/kernel/kernel-auth-service/src/main/java/io/mosip/kernel/auth/util/ProxyTokenGenerator.java
@@ -15,9 +15,6 @@ public class ProxyTokenGenerator {
 	
 	@Value("${auth.local.exp:1000000}")
 	long localExp;
-
-	@Value("${auth.local.secret:secret}")
-	String localSecret;
 	
 	@Value("${auth.local.mobileno}")
 	String mobileNO;
@@ -32,6 +29,6 @@ public class ProxyTokenGenerator {
 		return JWT.create().withSubject(subject).withClaim(AuthConstant.MOBILE, mobileNO)
 				.withClaim(AuthConstant.EMAIL, subject.concat(emailDomain))
 				.withClaim(AuthConstant.ROLES, localUserRoles).withExpiresAt(new Date(exp))
-				.sign(Algorithm.HMAC512(localSecret.getBytes()));
+				.sign(Algorithm.none());
 	}
 }

--- a/kernel/kernel-auth-service/src/main/resources/application-local.properties
+++ b/kernel/kernel-auth-service/src/main/resources/application-local.properties
@@ -59,25 +59,25 @@ authserver_datasource=ldap_1_DS
 admin_datasource=ldap_1_DS
 
 
-db_1_DS.datastore.ipaddress=jdbc:postgresql://<Database IP>:<Port>/mosip_iam
+db_1_DS.datastore.ipaddress=jdbc:h2\:mem\:mosip_iam;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS mosip
 db_1_DS.datastore.port=9001
-db_1_DS.datastore.username=iamuser
-db_1_DS.datastore.password=<Database Password>
-db_1_DS.datastore.driverClassName=org.postgresql.Driver
+db_1_DS.datastore.username=sa
+db_1_DS.datastore.password=
+db_1_DS.datastore.driverClassName=org.h2.Driver
 db_1_DS.datastore.schema=GOVT_OFFICERS
 
-db_2_DS.datastore.ipaddress=jdbc:postgresql://<Database IP>:<Port>/mosip_iam
+db_2_DS.datastore.ipaddress=jdbc:h2\:mem\:mosip_iam;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS mosip
 db_2_DS.datastore.port=9001
-db_2_DS.datastore.username=iamuser
-db_2_DS.datastore.password=<Database Password>
-db_2_DS.datastore.driverClassName=org.postgresql.Driver
+db_2_DS.datastore.username=sa
+db_2_DS.datastore.password=
+db_2_DS.datastore.driverClassName=org.h2.Driver
 db_2_DS.datastore.schema=GOVT_OFFICERS
 
-db_3_DS.keycloak.ipaddress=jdbc:postgresql://52.172.28.182:9001/keycloak
+db_3_DS.keycloak.ipaddress=jdbc:h2\:mem\:mosip;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS public
 db_3_DS.keycloak.port=9001
-db_3_DS.keycloak.username=postgres
-db_3_DS.keycloak.password=mosip
-db_3_DS.keycloak.driverClassName=org.postgresql.Driver
+db_3_DS.keycloak.username=sa
+db_3_DS.keycloak.password=
+db_3_DS.keycloak.driverClassName=org.h2.Driver
 
 ldap_1_DS.datastore.ipaddress=52.172.11.190
 #ldap_1_DS.datastore.ipaddress=localhost
@@ -92,10 +92,10 @@ ldap.roles.search.prefix=(&(objectClass=organizationalRole)(roleOccupant=
 ldap.roles.search.suffix=))
 ldap.roles.class=(objectClass=organizationalRole)
 
-iam.datasource.url=jdbc:postgresql://<Database IP>:<Port>/mosip_iam
-iam.datasource.username=iamuser
-iam.datasource.password=<Database Password>
-iam.datasource.driverClassName=org.postgresql.Driver
+iam.datasource.url=jdbc:h2\:mem\:mosip_iam;DB_CLOSE_DELAY=-1;INIT=CREATE SCHEMA IF NOT EXISTS mosip
+iam.datasource.username=sa
+iam.datasource.password=
+iam.datasource.driverClassName=org.h2.Driver
 
 logging.level.com.zaxxer.hikari.HikariConfig=DEBUG
 

--- a/kernel/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ZoneServiceImpl.java
+++ b/kernel/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ZoneServiceImpl.java
@@ -3,7 +3,6 @@ package io.mosip.kernel.masterdata.service.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +11,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import io.mosip.kernel.core.dataaccess.exception.DataAccessLayerException;
+import io.mosip.kernel.masterdata.constant.RegistrationCenterErrorCode;
 import io.mosip.kernel.masterdata.constant.ZoneErrorCode;
 import io.mosip.kernel.masterdata.dto.getresponse.ZoneNameResponseDto;
 import io.mosip.kernel.masterdata.dto.getresponse.extn.ZoneExtnDto;
@@ -149,7 +149,10 @@ public class ZoneServiceImpl implements ZoneService {
 		} catch (DataAccessException | DataAccessLayerException ex) {
 			throw new MasterDataServiceException("ADM-PKT-500", "Error occured while fetching packet");
 		}
-		Objects.nonNull(registrationCenter);
+		if(registrationCenter==null) {
+			throw new DataNotFoundException(RegistrationCenterErrorCode.REGISTRATION_CENTER_NOT_FOUND.getErrorCode(), RegistrationCenterErrorCode.REGISTRATION_CENTER_NOT_FOUND.getErrorMessage());
+		}
+		
 		return registrationCenter.getZoneCode();
 	}
 

--- a/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/LocationControllerIntegrationTest.java
+++ b/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/LocationControllerIntegrationTest.java
@@ -2,6 +2,8 @@ package io.mosip.kernel.masterdata.test.integration;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -19,7 +21,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -31,6 +35,7 @@ import io.mosip.kernel.core.dataaccess.exception.DataAccessLayerException;
 import io.mosip.kernel.core.http.RequestWrapper;
 import io.mosip.kernel.masterdata.dto.LocationCreateDto;
 import io.mosip.kernel.masterdata.dto.LocationDto;
+import io.mosip.kernel.masterdata.dto.getresponse.LocationHierarchyDto;
 import io.mosip.kernel.masterdata.entity.Location;
 import io.mosip.kernel.masterdata.entity.Machine;
 import io.mosip.kernel.masterdata.exception.MasterDataServiceException;
@@ -59,6 +64,7 @@ public class LocationControllerIntegrationTest {
 	private LocationCreateDto locationCreateDto;
 	private LocationDto dto2;
 	private List<Location> parentLocList;
+	private List<Object[]> locationObjects;
 
 	@MockBean
 	MasterdataCreationUtil masterdataCreationUtil;
@@ -92,6 +98,10 @@ public class LocationControllerIntegrationTest {
 		parentLocList = new ArrayList<>();
 		parentLocList.add(parentLoc);
 		doNothing().when(auditUtil).auditRequest(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+		Object[] object1= {(short) 1,"hierarchy_level_name",true};
+		Object[] object2= {(short) 2,"hierarchy_level_name",true};
+		locationObjects=Arrays.asList(object1,object2);
+		
 	}
 
 	@Test
@@ -115,6 +125,18 @@ public class LocationControllerIntegrationTest {
 		// when(repo.findLocationHierarchyByCodeAndLanguageCode(Mockito.any(),Mockito.any())).thenThrow(new
 		// MasterDataServiceException("","Parent location not found"));
 		// when(repo.findByNameAndLevelLangCode(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(parentLocList);
+		// when(repo.create(Mockito.any())).thenReturn(location1);
+		mockMvc.perform(post("/locations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
+				.andExpect(status().is5xxServerError());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void locationParentNotFoundException() throws Exception {
+		createRequest.setRequest(locationCreateDto);
+		String requestJson = mapper.writeValueAsString(createRequest);
+		when(masterdataCreationUtil.createMasterData(Location.class, locationCreateDto)).thenReturn(locationCreateDto);
+		when(repo.findLocationHierarchyByCodeAndLanguageCode(Mockito.any(), Mockito.any())).thenReturn(null);
 		// when(repo.create(Mockito.any())).thenReturn(location1);
 		mockMvc.perform(post("/locations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
 				.andExpect(status().is5xxServerError());
@@ -174,10 +196,57 @@ public class LocationControllerIntegrationTest {
 		dto1.setIsActive(true);
 		request.setRequest(dto1);
 		String requestJson = mapper.writeValueAsString(request);
+		when(repo.findLocationHierarchyByCodeAndLanguageCode(Mockito.any(), Mockito.any())).thenReturn(Arrays.asList(location1));
+		when(masterdataCreationUtil.updateMasterData(Location.class, dto1)).thenReturn(dto1);
+		when(repo.findLocationByCodeAndLanguageCode(Mockito.any(), Mockito.any())).thenReturn(location1);
 		when(repo.update(Mockito.any())).thenThrow(new IllegalArgumentException());
 		mockMvc.perform(put("/locations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
-				.andExpect(status().isOk());
+				.andExpect(status().is5xxServerError());
 	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void updateLocationNotFoundTest() throws Exception {
+		location1.setIsActive(true);
+		dto1.setIsActive(true);
+		request.setRequest(dto1);
+		String requestJson = mapper.writeValueAsString(request);
+		when(repo.findLocationHierarchyByCodeAndLanguageCode(Mockito.any(), Mockito.any())).thenReturn(Arrays.asList(location1));
+		when(masterdataCreationUtil.updateMasterData(Location.class, dto1)).thenReturn(dto1);
+		when(repo.findLocationByCodeAndLanguageCode(Mockito.any(), Mockito.any())).thenReturn(null);
+		mockMvc.perform(put("/locations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
+				.andExpect(status().is5xxServerError());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void updateChildStatusExceptionTest() throws Exception {
+		location1.setIsActive(true);
+		dto1.setIsActive(false);
+		request.setRequest(dto1);
+		String requestJson = mapper.writeValueAsString(request);
+		when(repo.findLocationHierarchyByCodeAndLanguageCode(Mockito.any(), Mockito.any())).thenReturn(Arrays.asList(location1));
+		
+		when(repo.findLocationHierarchyByParentLocCodeAndLanguageCode(Mockito.any(), Mockito.any())).thenReturn(Arrays.asList(location1));
+		mockMvc.perform(put("/locations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
+				.andExpect(status().is5xxServerError());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void updateLocationAlreadyExistsUnderHeirarchyExceptionTest() throws Exception {
+		location1.setIsActive(true);
+		dto1.setIsActive(true);
+		request.setRequest(dto1);
+		String requestJson = mapper.writeValueAsString(request);
+		when(repo.findLocationHierarchyByCodeAndLanguageCode(Mockito.any(), Mockito.any()))
+				.thenReturn(Arrays.asList(location1));
+		when(repo.findByNameAndLevelLangCode(Mockito.any(),Mockito.any(), Mockito.any())).thenReturn(Arrays.asList(location1));
+		mockMvc.perform(put("/locations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
+		.andExpect(status().isOk());
+	}
+	
+	
 
 	@Test
 	@WithUserDetails("global-admin")
@@ -355,5 +424,122 @@ public class LocationControllerIntegrationTest {
 		mockMvc.perform(post("/locations").contentType(MediaType.APPLICATION_JSON).content(requestJson))
 				.andExpect(status().is5xxServerError());
 	}
-
+	
+	@Test
+	@WithUserDetails("zonal-admin")
+	public void getLocationDetailsSuccess() throws Exception {
+		when(repo.findDistinctLocationHierarchyByIsDeletedFalse(Mockito.any())).thenReturn(locationObjects);
+		mockMvc.perform(get("/locations/eng").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("zonal-admin")
+	public void getLocationDetailsDataAccessException() throws Exception {
+		when(repo.findDistinctLocationHierarchyByIsDeletedFalse(Mockito.any())).thenThrow(new DataAccessLayerException("","",null));
+		mockMvc.perform(get("/locations/eng").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().is5xxServerError());
+	}
+	
+	@Test
+	@WithUserDetails("zonal-admin")
+	public void getLocationDetailsLocationsNotFound() throws Exception {
+		when(repo.findDistinctLocationHierarchyByIsDeletedFalse(Mockito.any())).thenReturn(new ArrayList<Object[]>());
+		mockMvc.perform(get("/locations/eng").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
+//	@Test
+//	@WithUserDetails("zonal-admin")
+//	public void getLocationHierarchyByLangCodeSuccess() throws Exception {
+//		Location location4 = new Location("BDR", "LOCATION NAME", (short) 3, "City", "MDDR", "eng", null);
+//		when(repo.findLocationHierarchyByParentLocCodeAndLanguageCode(Mockito.any(),Mockito.any())).thenReturn(Arrays.asList(location4)).thenReturn(Arrays.asList());
+//		when(repo.findLocationHierarchyByCodeAndLanguageCode(Mockito.any(),Mockito.any())).thenReturn(Arrays.asList(location1)).thenReturn(Arrays.asList(parentLoc)).thenReturn(Arrays.asList());
+//		mockMvc.perform(get("/locations/MDDR/eng").contentType(MediaType.APPLICATION_JSON))
+//				.andExpect(status().isOk());
+//	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void getLocationDataByHierarchyNameSuccess() throws Exception {
+		Location location4 = new Location("BDR", "LOCATION NAME", (short) 3, "City", "MDDR", "eng", null);
+		when(repo.findAllByHierarchyNameIgnoreCase(Mockito.any())).thenReturn(Arrays.asList(location4));
+		mockMvc.perform(get("/locations/locationhierarchy/City").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void getLocationDataByHierarchyNameDataAccessLayerException() throws Exception {
+		when(repo.findAllByHierarchyNameIgnoreCase(Mockito.any())).thenThrow(new DataAccessLayerException("","",null));
+		mockMvc.perform(get("/locations/locationhierarchy/City").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().is5xxServerError());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void getLocationDataByHierarchyNameLocationNotFound() throws Exception {
+		when(repo.findAllByHierarchyNameIgnoreCase(Mockito.any())).thenReturn(Arrays.asList());
+		mockMvc.perform(get("/locations/locationhierarchy/City").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void deleteLocationDetialsSuccess() throws Exception {
+		Location location4 = new Location("BDR", "LOCATION NAME", (short) 3, "City", "MDDR", "eng", null);
+		when(repo.findByCode(Mockito.any())).thenReturn(Arrays.asList(location4));
+		when(repo.update(Mockito.any(Location.class))).thenReturn(location4);
+		mockMvc.perform(delete("/locations/MDDR").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void deleteLocationDetialsLocationNotFound() throws Exception {
+		
+		when(repo.findByCode(Mockito.any())).thenReturn(Arrays.asList());
+		
+		mockMvc.perform(delete("/locations/MDDR").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void deleteLocationDetialsDataAccessLayerException() throws Exception {
+		
+		when(repo.findByCode(Mockito.any())).thenThrow(new DataAccessLayerException("","",null));
+		
+		mockMvc.perform(delete("/locations/MDDR").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().is5xxServerError());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void getImmediateChildrenByLocCodeAndLangCodeSuccess() throws Exception {
+		Location location4 = new Location("BDR", "LOCATION NAME", (short) 3, "City", "MDDR", "eng", null);
+		when(repo.findLocationHierarchyByParentLocCodeAndLanguageCode(Mockito.any(),Mockito.any())).thenReturn(Arrays.asList(location4));
+		
+		mockMvc.perform(get("/locations/immediatechildren/MDDR/eng").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void getImmediateChildrenByLocCodeAndLangCodeDataAcessException() throws Exception {
+		when(repo.findLocationHierarchyByParentLocCodeAndLanguageCode(Mockito.any(),Mockito.any())).thenThrow(DataAccessLayerException.class);
+		
+		mockMvc.perform(get("/locations/immediatechildren/MDDR/eng").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().is5xxServerError());
+	}
+	
+	@Test
+	@WithUserDetails("individual")
+	public void getImmediateChildrenByLocCodeAndLangCodeNotfound() throws Exception {
+		when(repo.findLocationHierarchyByParentLocCodeAndLanguageCode(Mockito.any(),Mockito.any())).thenReturn(Arrays.asList());
+		
+		mockMvc.perform(get("/locations/immediatechildren/MDDR/eng").contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+	
 }

--- a/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/LocationSearchFilterIntegrationTest.java
+++ b/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/LocationSearchFilterIntegrationTest.java
@@ -28,8 +28,10 @@ import org.springframework.test.web.servlet.MvcResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.mosip.kernel.core.dataaccess.exception.DataAccessLayerException;
 import io.mosip.kernel.core.http.RequestWrapper;
 import io.mosip.kernel.core.http.ResponseWrapper;
+import io.mosip.kernel.core.masterdata.util.model.Node;
 import io.mosip.kernel.core.masterdata.util.spi.UBtree;
 import io.mosip.kernel.masterdata.dto.request.FilterDto;
 import io.mosip.kernel.masterdata.dto.request.FilterValueDto;
@@ -79,6 +81,7 @@ public class LocationSearchFilterIntegrationTest {
 	private SearchDto searchDto;
 
 	private SearchFilter filter;
+	private SearchFilter filter1;
 
 	private RequestWrapper<SearchDto> request;
 
@@ -97,7 +100,11 @@ public class LocationSearchFilterIntegrationTest {
 		filter.setColumnName("city");
 		filter.setType("equals");
 		filter.setValue("Rabta");
-		searchDto.setFilters(Arrays.asList(filter));
+		filter1 = new SearchFilter();
+		filter1.setColumnName("isActive");
+		filter1.setType("equals");
+		filter1.setValue("true");
+		searchDto.setFilters(Arrays.asList(filter,filter1));
 		searchDto.setLanguageCode("eng");
 		searchDto.setPagination(pagination);
 		searchDto.setSort(Arrays.asList(sort));
@@ -117,11 +124,50 @@ public class LocationSearchFilterIntegrationTest {
 		location.setParentLocCode("PAR");
 		location.setHierarchyLevel((short) 2);
 		location.setName("10045");
+		location.setIsActive(Boolean.TRUE);
 		locations.add(location);
 		String json = objectMapper.writeValueAsString(request);
 		when(locationRepository.findAllByLangCode(Mockito.anyString())).thenReturn(locations);
 		when(locationRepository.findLocationByHierarchyLevel(Mockito.anyShort(), Mockito.anyString(),
 				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(location);
+		mockMvc.perform(post("/locations/search").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void searchLocationemptyFiltersTest() throws Exception {
+		List<Location> locations = new ArrayList<>();
+		List<Node<Location>> tree=new ArrayList<>();
+		Location location1 = new Location("1001","10045",(short)1,"region","1000","eng",null);
+		Location location2 = new Location("1002","10045",(short)2,"province","1001","eng",null);
+		Location location3 = new Location("1003","10045",(short)3,"city","1002","eng",null);
+		Location location4 = new Location("1004","10045",(short)4,"zone","1003","eng",null);
+		Location location5 = new Location("1005","10045",(short)5,"postalcode","1004","eng",null);
+		
+		locations.add(location1);
+		locations.add(location2);
+		locations.add(location3);
+		locations.add(location4);
+		locations.add(location5);
+		tree.add(new Node<>("1001",location1,"1000"));
+		tree.add(new Node<>("1002",location2,"1001"));
+		tree.add(new Node<>("1003",location3,"1002"));
+		tree.add(new Node<>("1004",location4,"1003"));
+		tree.add(new Node<>("1005",location5,"1004"));
+		Pagination pagination = new Pagination(0, 10);
+		searchDto = new SearchDto();
+		searchDto.setFilters(Arrays.asList());
+		searchDto.setLanguageCode("eng");
+		searchDto.setPagination(pagination);
+		searchDto.setSort(Arrays.asList(sort));
+		request.setRequest(searchDto);
+		String json = objectMapper.writeValueAsString(request);
+		when(locationRepository.findAllByLangCode(Mockito.anyString(),Mockito.anyBoolean())).thenReturn(locations);
+		when(locationTree.createTree(Mockito.any())).thenReturn(tree);
+		when(locationTree.findRootNode(Mockito.any())).thenReturn(tree.get(0));
+		when(locationTree.findLeafs(Mockito.any())).thenReturn(tree);
+		when(locationTree.getParentHierarchy(Mockito.any())).thenReturn(locations);
 		mockMvc.perform(post("/locations/search").contentType(MediaType.APPLICATION_JSON).content(json))
 				.andExpect(status().isOk());
 	}
@@ -152,20 +198,33 @@ public class LocationSearchFilterIntegrationTest {
 	@WithUserDetails("global-admin")
 	public void searchLocationStartsWithTest() throws Exception {
 		List<Location> locations = new ArrayList<>();
-		Location location = new Location();
-		location.setCode("1001");
-		location.setHierarchyName("postalCode");
-		location.setLangCode("eng");
-		location.setParentLocCode("PAR");
-		location.setHierarchyLevel((short) 2);
-		location.setName("10045");
-		locations.add(location);
+		List<Node<Location>> tree=new ArrayList<>();
+		Location location1 = new Location("1001","10045",(short)1,"region","1000","eng",null);
+		Location location2 = new Location("1002","10045",(short)2,"province","1001","eng",null);
+		Location location3 = new Location("1003","10045",(short)3,"city","1002","eng",null);
+		Location location4 = new Location("1004","10045",(short)4,"zone","1003","eng",null);
+		Location location5 = new Location("1005","10045",(short)5,"postalcode","1004","eng",null);
+		
+		locations.add(location1);
+		locations.add(location2);
+		locations.add(location3);
+		locations.add(location4);
+		locations.add(location5);
+		tree.add(new Node<>("1001",location1,"1000"));
+		tree.add(new Node<>("1002",location2,"1001"));
+		tree.add(new Node<>("1003",location3,"1002"));
+		tree.add(new Node<>("1004",location4,"1003"));
+		tree.add(new Node<>("1005",location5,"1004"));
 		filter.setType("startSWith");
 		searchDto.setFilters(Arrays.asList(filter));
 		String json = objectMapper.writeValueAsString(request);
 		when(locationRepository.findAllByLangCode(Mockito.anyString())).thenReturn(locations);
-		when(locationRepository.findLocationByHierarchyLevelContains(Mockito.anyShort(), Mockito.anyString(),
-				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(Arrays.asList(location));
+		when(locationRepository.findLocationByHierarchyLevelStartsWith(Mockito.anyShort(), Mockito.anyString(),
+				Mockito.anyString(), Mockito.anyBoolean())).thenReturn(locations);
+		when(locationTree.createTree(Mockito.any())).thenReturn(tree);
+		when(locationTree.findNode(Mockito.any(),Mockito.anyString())).thenReturn(tree.get(0));
+		when(locationTree.findLeafs(Mockito.any())).thenReturn(tree);
+		when(locationTree.getParentHierarchy(Mockito.any())).thenReturn(locations);
 		mockMvc.perform(post("/locations/search").contentType(MediaType.APPLICATION_JSON).content(json))
 				.andExpect(status().isOk());
 	}
@@ -256,11 +315,52 @@ public class LocationSearchFilterIntegrationTest {
 		location.setName("10045");
 		locations.add(location);
 		when(locationRepository.findLocationAllHierarchyNames()).thenReturn(hierarchyNames);
-		when(locationRepository.findAllHierarchyNameAndNameValueForEmptyTextFilter(Mockito.anyString(),
+		when(locationRepository.findAllHierarchyNameAndNameValueForTextFilter(Mockito.anyString(),Mockito.anyString(),
 				Mockito.anyString())).thenReturn(locations);
 
 		mockMvc.perform(post("/locations/filtervalues").contentType(MediaType.APPLICATION_JSON).content(json))
 				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void filterEmptyTypeTest() throws Exception {
+		FilterDto filterDto = new FilterDto();
+		filterDto.setColumnName("Zone");
+		filterDto.setType("");
+		filterDto.setText("abc");
+		FilterValueDto filterValueDto = new FilterValueDto();
+		filterValueDto.setFilters(Arrays.asList(filterDto));
+		filterValueDto.setLanguageCode("eng");
+		RequestWrapper<FilterValueDto> requestDto = new RequestWrapper<>();
+		requestDto.setRequest(filterValueDto);
+		String json = objectMapper.writeValueAsString(requestDto);
+		List<String> hierarchyNames = new ArrayList<>();
+		hierarchyNames.add("Zone");
+		
+		when(locationRepository.findLocationAllHierarchyNames()).thenReturn(hierarchyNames);
+		
+
+		mockMvc.perform(post("/locations/filtervalues").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void filterDataAccessexceptionTest() throws Exception {
+		FilterDto filterDto = new FilterDto();
+		filterDto.setColumnName("Zone");
+		filterDto.setType("");
+		filterDto.setText("abc");
+		FilterValueDto filterValueDto = new FilterValueDto();
+		filterValueDto.setFilters(Arrays.asList(filterDto));
+		filterValueDto.setLanguageCode("eng");
+		RequestWrapper<FilterValueDto> requestDto = new RequestWrapper<>();
+		requestDto.setRequest(filterValueDto);
+		String json = objectMapper.writeValueAsString(requestDto);
+		when(locationRepository.findLocationAllHierarchyNames()).thenThrow(DataAccessLayerException.class);
+		mockMvc.perform(post("/locations/filtervalues").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().is5xxServerError());
 	}
 
 	@Test
@@ -282,6 +382,29 @@ public class LocationSearchFilterIntegrationTest {
 		when(locationRepository.findLocationAllHierarchyNames()).thenReturn(hierarchyNames);
 		when(locationRepository.findDistinctHierarchyNameAndNameValueForEmptyTextFilter(Mockito.anyString(),
 				Mockito.anyString())).thenReturn(hierarchyNames);
+
+		mockMvc.perform(post("/locations/filtervalues").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void filterUniqueIsActiveColumnTest() throws Exception {
+		FilterDto filterDto = new FilterDto();
+		filterDto.setColumnName("isActive");
+		filterDto.setType("unique");
+		filterDto.setText("true");
+		FilterValueDto filterValueDto = new FilterValueDto();
+		filterValueDto.setFilters(Arrays.asList(filterDto));
+		filterValueDto.setLanguageCode("eng");
+		RequestWrapper<FilterValueDto> requestDto = new RequestWrapper<>();
+		requestDto.setRequest(filterValueDto);
+		String json = objectMapper.writeValueAsString(requestDto);
+		List<String> hierarchyNames = new ArrayList<>();
+		hierarchyNames.add("Zone");
+
+		when(locationRepository.findLocationAllHierarchyNames()).thenReturn(hierarchyNames);
+		when(masterDataFilterHelper.filterValues(Mockito.any(), Mockito.any(),Mockito.any())).thenReturn(Arrays.asList("a","b"));
 
 		mockMvc.perform(post("/locations/filtervalues").contentType(MediaType.APPLICATION_JSON).content(json))
 				.andExpect(status().isOk());

--- a/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/RegistrationCenterSearchFilterIntegrationTest.java
+++ b/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/RegistrationCenterSearchFilterIntegrationTest.java
@@ -1,0 +1,244 @@
+package io.mosip.kernel.masterdata.test.integration;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.mosip.kernel.core.http.RequestWrapper;
+import io.mosip.kernel.masterdata.dto.request.FilterDto;
+import io.mosip.kernel.masterdata.dto.request.FilterValueDto;
+import io.mosip.kernel.masterdata.dto.request.Pagination;
+import io.mosip.kernel.masterdata.dto.request.SearchDto;
+import io.mosip.kernel.masterdata.dto.request.SearchFilter;
+import io.mosip.kernel.masterdata.dto.request.SearchSort;
+import io.mosip.kernel.masterdata.dto.response.PageResponseDto;
+import io.mosip.kernel.masterdata.dto.response.RegistrationCenterSearchDto;
+import io.mosip.kernel.masterdata.entity.Location;
+import io.mosip.kernel.masterdata.entity.Zone;
+import io.mosip.kernel.masterdata.repository.RegistrationCenterRepository;
+import io.mosip.kernel.masterdata.test.TestBootApplication;
+import io.mosip.kernel.masterdata.utils.AuditUtil;
+import io.mosip.kernel.masterdata.utils.LocationUtils;
+import io.mosip.kernel.masterdata.utils.MasterDataFilterHelper;
+import io.mosip.kernel.masterdata.utils.PageUtils;
+import io.mosip.kernel.masterdata.utils.RegistrationCenterServiceHelper;
+import io.mosip.kernel.masterdata.utils.ZoneUtils;
+import io.mosip.kernel.masterdata.validator.FilterColumnValidator;
+import io.mosip.kernel.masterdata.validator.FilterTypeValidator;
+
+@SpringBootTest(classes = TestBootApplication.class)
+@RunWith(SpringRunner.class)
+@AutoConfigureMockMvc
+public class RegistrationCenterSearchFilterIntegrationTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@MockBean
+	private PageUtils pageUtils;
+
+	@MockBean
+	private MasterDataFilterHelper masterDataFilterHelper;
+
+	@MockBean
+	private RegistrationCenterRepository registrationCenterRepository;
+	@MockBean
+	private RegistrationCenterServiceHelper serviceHelper;
+	@MockBean
+	private LocationUtils locationUtils;
+	@MockBean
+	private FilterTypeValidator filterTypeValidator;
+	@MockBean
+	private ZoneUtils zoneUtils;
+	@MockBean
+	private FilterColumnValidator filterColumnValidator;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private SearchSort sort;
+
+	private SearchDto searchDto;
+
+	private SearchFilter filter;
+	private SearchFilter filter1;
+
+	private RequestWrapper<SearchDto> request;
+	private RequestWrapper<FilterValueDto> requestDto;
+	private List<Zone> zones;
+
+	@MockBean
+	private AuditUtil auditUtil;
+	
+	@Before
+	public void setup() throws JsonProcessingException {
+		sort = new SearchSort();
+		sort.setSortType("ASC");
+		sort.setSortField("name");
+		request = new RequestWrapper<>();
+		searchDto = new SearchDto();
+		Pagination pagination = new Pagination(0, 10);
+		filter = new SearchFilter();
+		filter.setColumnName("zone");
+		filter.setType("equals");
+		filter.setValue("Rabta");
+		filter1 = new SearchFilter();
+		filter1.setColumnName("centertypename");
+		filter1.setType("equals");
+		filter1.setValue("regular");
+		searchDto.setFilters(Arrays.asList(filter,filter1));
+		searchDto.setLanguageCode("eng");
+		searchDto.setPagination(pagination);
+		searchDto.setSort(Arrays.asList(sort));
+		request.setRequest(searchDto);
+		Zone zone = new Zone();
+		zone.setCode("JRD");
+		zone.setLangCode("eng");
+		zone.setHierarchyPath("MOR/NTH/ORT/JRD");
+		Zone zone1 = new Zone();
+		zone1.setCode("TZT");
+		zone1.setLangCode("eng");
+		zone1.setHierarchyPath("MOR/STH/SOS/TZT");
+		Zone zone2 = new Zone();
+		zone2.setCode("TTA");
+		zone2.setLangCode("eng");
+		zone2.setHierarchyPath("MOR/STH/SOS/TTA");
+		Zone zone3 = new Zone();
+		zone3.setCode("BRT");
+		zone3.setLangCode("eng");
+		zone3.setHierarchyPath("MOR/NTH/ORT/BRK");
+		Zone zone4 = new Zone();
+		zone4.setCode("CST");
+		zone4.setLangCode("eng");
+		zone4.setHierarchyPath("MOR/NTH/ORT/CST");
+		Zone zone6 = new Zone();
+		zone6.setCode("NTH");
+		zone6.setLangCode("eng");
+		zone6.setHierarchyPath("MOR/NTH");
+		Zone zone5 = new Zone();
+		zone5.setCode("NTH");
+		zone5.setLangCode("eng");
+		zone5.setHierarchyPath("MOR/STH");
+		zones=new ArrayList<>();
+		zones.addAll(Arrays.asList(zone1,zone2,zone3,zone4,zone5));
+		FilterDto filterDto = new FilterDto();
+		filterDto.setColumnName("Zone");
+		filterDto.setType("invalidType");
+		filterDto.setText("abc");
+		FilterValueDto filterValueDto = new FilterValueDto();
+		filterValueDto.setFilters(Arrays.asList(filterDto));
+		filterValueDto.setLanguageCode("eng");
+		requestDto = new RequestWrapper<>();
+		requestDto.setRequest(filterValueDto);
+		doNothing().when(auditUtil).auditRequest(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+	}
+	@Test
+	@WithUserDetails("global-admin")
+	public void searchRegistrationCenterTest() throws Exception {
+		List<Location> locations = new ArrayList<>();
+		Location location = new Location();
+		location.setCode("1001");
+		location.setHierarchyName("postalCode");
+		location.setLangCode("eng");
+		location.setParentLocCode("PAR");
+		location.setHierarchyLevel((short) 2);
+		location.setName("10045");
+		location.setIsActive(Boolean.TRUE);
+		locations.add(location);
+		String json = objectMapper.writeValueAsString(request);
+		when(serviceHelper.fetchLocations(Mockito.anyString())).thenReturn(locations);
+		doNothing().when(serviceHelper).centerTypeSearch(Mockito.any(), Mockito.any(), Mockito.any());
+		when(serviceHelper.locationSearch(Mockito.any())).thenReturn(location);
+		when(locationUtils.getDescedants(Mockito.any(), Mockito.any())).thenReturn(locations);
+		when(serviceHelper.buildLocationSearchFilter(Mockito.any())).thenReturn(Arrays.asList(filter,filter1));
+		when(serviceHelper.fetchUserZone(Mockito.any(),Mockito.any())).thenReturn(zones);
+		when(filterTypeValidator.validate(Mockito.any(),Mockito.any())).thenReturn(true);
+		when(serviceHelper.searchCenter(Mockito.any(),Mockito.any(),Mockito.any(),Mockito.any(),Mockito.any())).
+		thenReturn(new PageResponseDto<>(1, 20, 30, null));
+		mockMvc.perform(post("/registrationcenters/search").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void searchRegistrationCenterNotfoundTest() throws Exception {
+		List<Location> locations = new ArrayList<>();
+		Location location = new Location();
+		location.setCode("1001");
+		location.setHierarchyName("postalCode");
+		location.setLangCode("eng");
+		location.setParentLocCode("PAR");
+		location.setHierarchyLevel((short) 2);
+		location.setName("10045");
+		location.setIsActive(Boolean.TRUE);
+		locations.add(location);
+		String json = objectMapper.writeValueAsString(request);
+		when(serviceHelper.fetchLocations(Mockito.anyString())).thenReturn(locations);
+		doNothing().when(serviceHelper).centerTypeSearch(Mockito.any(), Mockito.any(), Mockito.any());
+		when(serviceHelper.locationSearch(Mockito.any())).thenReturn(null);
+		when(filterTypeValidator.validate(Mockito.any(),Mockito.any())).thenReturn(false);
+		mockMvc.perform(post("/registrationcenters/search").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void registrationCenterFilterValuesTest() throws Exception {
+		List<Location> locations = new ArrayList<>();
+		Location location = new Location();
+		location.setCode("1001");
+		location.setHierarchyName("postalCode");
+		location.setLangCode("eng");
+		location.setParentLocCode("PAR");
+		location.setHierarchyLevel((short) 2);
+		location.setName("10045");
+		location.setIsActive(Boolean.TRUE);
+		locations.add(location);
+		String json = objectMapper.writeValueAsString(requestDto);
+		when(zoneUtils.getUserZones()).thenReturn(zones);
+		when(filterColumnValidator.validate(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(true);
+		when(masterDataFilterHelper.filterValues(Mockito.any(),Mockito.any(),Mockito.any())).thenReturn(Arrays.asList("a"));
+		
+		mockMvc.perform(post("/registrationcenters/filtervalues").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk());
+	}
+	
+	@Test
+	@WithUserDetails("global-admin")
+	public void registrationCenterFilterValuesZoneNotFoundTest() throws Exception {
+		List<Location> locations = new ArrayList<>();
+		Location location = new Location();
+		location.setCode("1001");
+		location.setHierarchyName("postalCode");
+		location.setLangCode("eng");
+		location.setParentLocCode("PAR");
+		location.setHierarchyLevel((short) 2);
+		location.setName("10045");
+		location.setIsActive(Boolean.TRUE);
+		locations.add(location);
+		String json = objectMapper.writeValueAsString(requestDto);
+		when(zoneUtils.getUserZones()).thenReturn(null);
+		
+		mockMvc.perform(post("/registrationcenters/filtervalues").contentType(MediaType.APPLICATION_JSON).content(json))
+				.andExpect(status().isOk());
+	}
+}

--- a/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/ZoneIntegrationTest.java
+++ b/kernel/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/integration/ZoneIntegrationTest.java
@@ -122,6 +122,15 @@ public class ZoneIntegrationTest {
 				.thenThrow(DataRetrievalFailureException.class);
 		mockMvc.perform(get("/zones/authorize?rid=12234234234234234")).andExpect(status().isInternalServerError());
 	}
+	
+	@Test
+	@WithUserDetails("zonal-admin")
+	public void authorizeZoneEmptyTest() throws Exception {
+
+		when(registrationCenterRepo.findByIdAndLangCode(Mockito.anyString(), Mockito.anyString()))
+				.thenReturn(null);
+		mockMvc.perform(get("/zones/authorize?rid=12234234234234234")).andExpect(status().isOk());
+	}
 
 	@Test
 	@WithUserDetails("zonal-admin")

--- a/kernel/kernel-otpmanager-service/src/main/java/io/mosip/kernel/otpmanager/service/impl/OtpValidatorServiceImpl.java
+++ b/kernel/kernel-otpmanager-service/src/main/java/io/mosip/kernel/otpmanager/service/impl/OtpValidatorServiceImpl.java
@@ -73,7 +73,7 @@ public class OtpValidatorServiceImpl implements OtpValidator<ResponseEntity<OtpV
 	public ResponseEntity<OtpValidatorResponseDto> validateOtp(String key, String otp) {
 		ResponseEntity<OtpValidatorResponseDto> validationResponseEntity;
 		if(activeProfile.equalsIgnoreCase("local")) {
-		proxyForLocalProfile(otp);
+		return proxyForLocalProfile(otp);
 		}
 		// This method validates the input parameters.
 		otpUtils.validateOtpRequestArguments(key, otp);


### PR DESCRIPTION
This changes are done for users in local profile 
1. User proxy token validation with NONE algorithm
2. Client token validation with NONE algorithm
3. Send OTP feature will now have configured mock OTP and Mock validation for that OTP.
4. User can make his own token with none algo and own Roles and pass which will be validated in local profile