### PR TITLE
[MOS-31276] Added scaled score along with internal score and version

### DIFF
--- a/kernel/kernel-bioapi-provider/pom.xml
+++ b/kernel/kernel-bioapi-provider/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>kernel-bioapi-provider</artifactId>
-	<version>1.0.6</version>
+	<version>1.0.7</version>
 	<name>kernel-bioapi-provider</name>
 	<description>bioapi provider</description>
 	<packaging>jar</packaging>

--- a/kernel/kernel-bioapi-provider/src/main/java/io/mosip/kernel/bioapi/impl/BioApiImpl.java
+++ b/kernel/kernel-bioapi-provider/src/main/java/io/mosip/kernel/bioapi/impl/BioApiImpl.java
@@ -58,8 +58,10 @@ public class BioApiImpl implements IBioApi {
 			if (Objects.nonNull(recordedValue) && Objects.nonNull(recordedValue.getBdb())
 					&& recordedValue.getBdb().length != 0 && Arrays.equals(recordedValue.getBdb(), sample.getBdb())) {
 				matchingScore[count].setInternalScore(90);
+				matchingScore[count].setScaleScore(90);
 			} else {
 				matchingScore[count].setInternalScore(new SecureRandom().nextInt(50));
+				matchingScore[count].setScaleScore(new SecureRandom().nextInt(50));
 			}
 			count++;
 		}
@@ -90,6 +92,7 @@ public class BioApiImpl implements IBioApi {
 		CompositeScore compositeScore = new CompositeScore();
 		compositeScore.setIndividualScores(matchingScore);
 		compositeScore.setInternalScore((long) (sum / matchingScore.length));
+		compositeScore.setScaledScore((long) (sum / matchingScore.length));
 		return compositeScore;
 	}
 

--- a/kernel/kernel-bioapi-provider/src/main/java/io/mosip/kernel/bioapi/impl/BioApiImpl.java
+++ b/kernel/kernel-bioapi-provider/src/main/java/io/mosip/kernel/bioapi/impl/BioApiImpl.java
@@ -60,8 +60,9 @@ public class BioApiImpl implements IBioApi {
 				matchingScore[count].setInternalScore(90);
 				matchingScore[count].setScaleScore(90);
 			} else {
-				matchingScore[count].setInternalScore(new SecureRandom().nextInt(50));
-				matchingScore[count].setScaleScore(new SecureRandom().nextInt(50));
+				int randomNumebr = new SecureRandom().nextInt(50);
+				matchingScore[count].setInternalScore(randomNumebr);
+				matchingScore[count].setScaleScore(randomNumebr);
 			}
 			count++;
 		}
@@ -91,8 +92,9 @@ public class BioApiImpl implements IBioApi {
 		double sum = Arrays.stream(matchingScore).mapToDouble(Score::getInternalScore).sum();
 		CompositeScore compositeScore = new CompositeScore();
 		compositeScore.setIndividualScores(matchingScore);
-		compositeScore.setInternalScore((long) (sum / matchingScore.length));
-		compositeScore.setScaledScore((long) (sum / matchingScore.length));
+		long compositeMatchScore = (long) (sum / matchingScore.length);
+		compositeScore.setInternalScore(compositeMatchScore );
+		compositeScore.setScaledScore(compositeMatchScore);
 		return compositeScore;
 	}
 

--- a/kernel/kernel-bioapi-provider/src/test/java/io/mosip/kernel/bioapi/impl/BioApiTest.java
+++ b/kernel/kernel-bioapi-provider/src/test/java/io/mosip/kernel/bioapi/impl/BioApiTest.java
@@ -65,12 +65,14 @@ public class BioApiTest {
 		assertEquals(60, checkQuality.getInternalScore());
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void matchTest() {
 		BIR BIR = birDataFromXML.get(0);
 		Score[] match = bioApiImpl.match(BIR, birDataFromXML.stream().toArray(BIR[]::new), null);
 		Score highestScore = Arrays.stream(match).max(Comparator.comparing(Score::getInternalScore)).get();
 		assertEquals(90, highestScore.getInternalScore());
+		assertEquals(90, highestScore.getScaleScore());
 	}
 
 	@Test
@@ -79,6 +81,7 @@ public class BioApiTest {
 				birDataFromXML2.stream().toArray(BIR[]::new), null);
 		for (Score score : compositeMatch.getIndividualScores()) {
 			assertEquals(90, score.getInternalScore());
+			assertEquals(90, score.getScaleScore());
 		}
 		assertEquals(90, compositeMatch.getInternalScore());
 	}

--- a/kernel/kernel-bioapi-provider/src/test/java/io/mosip/kernel/bioapi/impl/BioApiTest.java
+++ b/kernel/kernel-bioapi-provider/src/test/java/io/mosip/kernel/bioapi/impl/BioApiTest.java
@@ -72,7 +72,7 @@ public class BioApiTest {
 		Score[] match = bioApiImpl.match(BIR, birDataFromXML.stream().toArray(BIR[]::new), null);
 		Score highestScore = Arrays.stream(match).max(Comparator.comparing(Score::getInternalScore)).get();
 		assertEquals(90, highestScore.getInternalScore());
-		assertEquals(90, highestScore.getScaleScore());
+		assertEquals(90, highestScore.getScaleScore(),0.00);
 	}
 
 	@Test
@@ -81,7 +81,7 @@ public class BioApiTest {
 				birDataFromXML2.stream().toArray(BIR[]::new), null);
 		for (Score score : compositeMatch.getIndividualScores()) {
 			assertEquals(90, score.getInternalScore());
-			assertEquals(90, score.getScaleScore());
+			assertEquals(90, score.getScaleScore(),0.00);
 		}
 		assertEquals(90, compositeMatch.getInternalScore());
 	}


### PR DESCRIPTION
The following changes have been made for kernel-bioapi-provider.
1. Added scaled score along with the Internal score.
2. version has been changed to 1.0.7