### PR TITLE
Move the latest version of kernel jars

### DIFF
--- a/kernel/kernel-keymanager-service/pom.xml
+++ b/kernel/kernel-keymanager-service/pom.xml
@@ -14,7 +14,7 @@
 	<name>kernel-keymanager-service</name>
 
 	<properties>
-		<kernel.core.version>1.0.8</kernel.core.version>
+		<kernel.core.version>1.0.9-SNAPSHOT</kernel.core.version>
 		<kernel.auth.adaptor.version>1.0.6</kernel.auth.adaptor.version>
 		<kernel-dataaccess-hibernate.version>1.0.7</kernel-dataaccess-hibernate.version>
 		<kernel.crypto.jce.version>1.0.6</kernel.crypto.jce.version>

--- a/kernel/kernel-notification-service/pom.xml
+++ b/kernel/kernel-notification-service/pom.xml
@@ -13,8 +13,8 @@
 		<version>1.0.6</version>
 	</parent>
 	<properties>
-	<kernel.core.version>1.0.8</kernel.core.version>
-		<kernel.auth-adapter.version>1.0.8</kernel.auth-adapter.version>
+	<kernel.core.version>1.0.8-SNAPSHOT</kernel.core.version>
+		<kernel.auth-adapter.version>1.0.8-SNAPSHOT</kernel.auth-adapter.version>
 		<kernel.applicant-type.version>1.0.6</kernel.applicant-type.version>
 		 <kernel.dataaccess-hibernate.version>1.0.6</kernel.dataaccess-hibernate.version>
 		<kernel.logger.version>1.0.6</kernel.logger.version>


### PR DESCRIPTION
The 1.0.8 core is not available in the maven repo. Also its wise to move all our kernel to latest so we can avoid issues of upgrading later.