### PR TITLE
MOSIP-10935 : Packet manager to minio connection performance issue fixed

### DIFF
--- a/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
+++ b/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
@@ -57,7 +57,7 @@ public class S3Adapter implements ObjectStoreAdapter {
     @Value("${object.store.connection.max.retry:20}")
     private int maxRetry;
 
-    @Value("${object.store.max.connection:200}")
+    @Value("${object.store.max.connection:10}")
     private int maxConnection;
 
     private int retry = 0;
@@ -150,17 +150,25 @@ public class S3Adapter implements ObjectStoreAdapter {
     @Override
     public Map<String, Object> getMetaData(String account, String container, String source, String process,
                                            String objectName) {
-
+        S3Object s3Object = null;
         try {
             Map<String, Object> metaData = new HashMap<>();
             String finalObjectName = ObjectStoreUtil.getName(source, process, objectName);
-            ObjectMetadata objectMetadata = getConnection(container).getObject(container, finalObjectName).getObjectMetadata();
+            s3Object = getConnection(container).getObject(container, finalObjectName);
+            ObjectMetadata objectMetadata = s3Object.getObjectMetadata();
             if (objectMetadata != null && objectMetadata.getUserMetadata() != null)
                 objectMetadata.getUserMetadata().entrySet().forEach(entry -> metaData.put(entry.getKey(), entry.getValue()));
             return metaData;
         } catch (Exception e) {
             LOGGER.error(SESSIONID, REGISTRATIONID,"Exception occured to getMetaData for : " + container, ExceptionUtils.getStackTrace(e));
             throw new ObjectStoreAdapterException(OBJECT_STORE_NOT_ACCESSIBLE.getErrorCode(), OBJECT_STORE_NOT_ACCESSIBLE.getErrorMessage(), e);
+        } finally {
+            try {
+                if (s3Object != null)
+                    s3Object.close();
+            } catch (IOException e) {
+                LOGGER.error(SESSIONID, REGISTRATIONID,"IO occured : " + container, ExceptionUtils.getStackTrace(e));
+            }
         }
     }
 

--- a/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
+++ b/kernel/object-store/src/main/java/io/mosip/commons/khazana/impl/S3Adapter.java
@@ -57,7 +57,7 @@ public class S3Adapter implements ObjectStoreAdapter {
     @Value("${object.store.connection.max.retry:20}")
     private int maxRetry;
 
-    @Value("${object.store.max.connection:10}")
+    @Value("${object.store.max.connection:200}")
     private int maxConnection;
 
     private int retry = 0;


### PR DESCRIPTION
Received S3 object was not closed in one method, causing the all the free http connections to be consumed and causing delay in processing the packets. As fix, closed the connection in the finally block.