### PR TITLE
MOSIP-11049 : Isolate assigned vids to a separate table to improve performance

### DIFF
--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/IDGeneratorVertxApplication.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/IDGeneratorVertxApplication.java
@@ -29,6 +29,7 @@ import io.mosip.kernel.uingenerator.verticle.UinTransferVerticle;
 import io.mosip.kernel.vidgenerator.constant.EventType;
 import io.mosip.kernel.vidgenerator.constant.VIDGeneratorConstant;
 import io.mosip.kernel.vidgenerator.verticle.VidExpiryVerticle;
+import io.mosip.kernel.vidgenerator.verticle.VidIsolatorVerticle;
 import io.mosip.kernel.vidgenerator.verticle.VidPoolCheckerVerticle;
 import io.mosip.kernel.vidgenerator.verticle.VidPopulatorVerticle;
 import io.vertx.config.ConfigRetriever;
@@ -170,7 +171,7 @@ public class IDGeneratorVertxApplication {
 		DeploymentOptions workerOptions = new DeploymentOptions().setWorker(true);
 		vertx = Vertx.vertx(options);
 		Verticle[] workerVerticles = { new VidPoolCheckerVerticle(context), new VidPopulatorVerticle(context),
-				new VidExpiryVerticle(context) };
+				new VidExpiryVerticle(context), new VidIsolatorVerticle(context) };
 		Stream.of(workerVerticles).forEach(verticle -> deploy(verticle, workerOptions, vertx));
 		vertx.setTimer(1000, handler -> initVIDPool());
 		Verticle[] uinVerticles = { new UinGeneratorVerticle(context),new UinTransferVerticle(context)};

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/constant/VidIsolatorSchedulerConstants.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/constant/VidIsolatorSchedulerConstants.java
@@ -1,0 +1,32 @@
+package io.mosip.kernel.vidgenerator.constant;
+
+public class VidIsolatorSchedulerConstants {
+
+	private VidIsolatorSchedulerConstants() {
+
+	}
+
+	public static final String CEYLON_SCHEDULER = "ceylon:herd.schedule.chime/0.2.0";
+	public static final String TIMER_EVENT = "scheduler:vid_isolator";
+	public static final String TYPE = "type";
+	public static final String SECONDS = "seconds";
+	public static final String MINUTES = "minutes";
+	public static final String HOURS = "hours";
+	public static final String DAY_OF_MONTH = "days of month";
+	public static final String MONTHS = "months";
+	public static final String DAYS_OF_WEEK = "days of week";
+	public static final String TYPE_VALUE = "kernel.vid.isolator-scheduler-type";
+	public static final String SECONDS_VALUE = "kernel.vid.isolator-scheduler-seconds";
+	public static final String MINUTES_VALUE = "kernel.vid.isolator-scheduler-minutes";
+	public static final String HOURS_VALUE = "kernel.vid.isolator-scheduler-hours";
+	public static final String DAY_OF_MONTH_VALUE = "kernel.vid.isolator-scheduler-days_of_month";
+	public static final String MONTHS_VALUE = "kernel.vid.isolator-scheduler-months";
+	public static final String DAYS_OF_WEEK_VALUE = "kernel.vid.isolator-scheduler-days_of_week";
+	public static final String CHIME = "chime";
+	public static final String OPERATION = "operation";
+	public static final String OPERATION_VALUE = "create";
+	public static final String NAME = "name";
+	public static final String NAME_VALUE = "scheduler:vid_isolator";
+	public static final String DESCRIPTION = "description";
+
+}

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/entity/VidAssignedEntity.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/entity/VidAssignedEntity.java
@@ -1,0 +1,48 @@
+package io.mosip.kernel.vidgenerator.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Entity class for vid assigned bean
+ * 
+ * @author Vishwanath V
+ *
+ */
+
+@Entity
+@Table(name = "vid_assigned", schema = "kernel")
+@Data
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class VidAssignedEntity extends BaseEntity {
+
+	/**
+	 * Field for vid
+	 */
+	@Id
+	@Column(name = "vid", unique = true, nullable = false, updatable = false, length = 28)
+	private String vid;
+
+	/**
+	 * Field whether this vid is used
+	 */
+	@Column(name = "vid_status", nullable = false, length = 16)
+	private String status;
+
+	/**
+	 * The field createdtimes
+	 */
+	@Column(name = "expiry_dtimes")
+	private LocalDateTime vidExpiry;
+}

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/repository/VidAssignedRepository.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/repository/VidAssignedRepository.java
@@ -1,0 +1,13 @@
+package io.mosip.kernel.vidgenerator.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.mosip.kernel.vidgenerator.entity.VidAssignedEntity;
+
+public interface VidAssignedRepository extends JpaRepository<VidAssignedEntity, String> {
+
+	List<VidAssignedEntity> findByStatusAndIsDeletedFalse(String status);
+
+}

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/router/VidFetcherRouter.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/router/VidFetcherRouter.java
@@ -86,6 +86,7 @@ public class VidFetcherRouter {
 								VIDGeneratorErrorCode.VID_EXPIRY_DATE_EMPTY.getErrorCode(),
 								VIDGeneratorErrorCode.VID_EXPIRY_DATE_EMPTY.getErrorMessage());
 						setError(routingContext, error, blockingCodeHandler);
+						return;
 					}
 					DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(UTC_DATETIME_PATTERN);
 					try {
@@ -95,12 +96,14 @@ public class VidFetcherRouter {
 								VIDGeneratorErrorCode.VID_EXPIRY_DATE_PATTERN_INVALID.getErrorCode(),
 								VIDGeneratorErrorCode.VID_EXPIRY_DATE_PATTERN_INVALID.getErrorMessage());
 						setError(routingContext, error, blockingCodeHandler);
+						return;
 					}
 					if (expiryTime.isBefore(DateUtils.getUTCCurrentDateTime())) {
 						ServiceError error = new ServiceError(
 								VIDGeneratorErrorCode.VID_EXPIRY_DATE_INVALID.getErrorCode(),
 								VIDGeneratorErrorCode.VID_EXPIRY_DATE_INVALID.getErrorMessage());
 						setError(routingContext, error, blockingCodeHandler);
+						return;
 					}
 				}
 				VidFetchResponseDto vidFetchResponseDto = null;
@@ -109,6 +112,7 @@ public class VidFetcherRouter {
 				} catch (VidGeneratorServiceException exception) {
 					ServiceError error = new ServiceError(exception.getErrorCode(), exception.getMessage());
 					setError(routingContext, error, blockingCodeHandler);
+					return;
 				}
 				String timestamp = DateUtils.getUTCCurrentDateTimeString();
 				reswrp.setResponsetime(DateUtils.convertUTCToLocalDateTime(timestamp));

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/service/VidService.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/service/VidService.java
@@ -15,4 +15,6 @@ public interface VidService {
 
 	boolean saveVID(VidEntity vid);
 
+	void isolateAssignedVids();
+
 }

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidIsolatorVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidIsolatorVerticle.java
@@ -1,0 +1,85 @@
+package io.mosip.kernel.vidgenerator.verticle;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+import io.mosip.kernel.vidgenerator.constant.VidIsolatorSchedulerConstants;
+import io.mosip.kernel.vidgenerator.service.VidService;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+public class VidIsolatorVerticle extends AbstractVerticle {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(VidIsolatorVerticle.class);
+
+	private VidService vidService;
+
+	private Environment environment;
+
+	public VidIsolatorVerticle(final ApplicationContext context) {
+		this.environment = context.getBean(Environment.class);
+		this.vidService = context.getBean(VidService.class);
+	}
+
+	@Override
+	public void start(Future<Void> startFuture) throws Exception {
+		vertx.deployVerticle(VidIsolatorSchedulerConstants.CEYLON_SCHEDULER, this::schedulerResult);
+	}
+
+	public void schedulerResult(AsyncResult<String> result) {
+		if (result.succeeded()) {
+			LOGGER.info("VidIsolatorVerticle deployment successfull");
+			cronScheduling(vertx);
+		} else if (result.failed()) {
+			LOGGER.error("VidIsolatorVerticle deployment failed with cause ", result.cause());
+		}
+	}
+
+	/**
+	 * This method does the cron scheduling by fetchin cron expression from config
+	 * serverl
+	 *
+	 * @param vertx the vertx
+	 */
+	private void cronScheduling(Vertx vertx) {
+
+		EventBus eventBus = vertx.eventBus();
+
+		MessageConsumer<JsonObject> consumer = eventBus.consumer(VidIsolatorSchedulerConstants.NAME_VALUE);
+
+		// handle chime event
+		consumer.handler(message -> vidService.isolateAssignedVids());
+
+		JsonObject timer = new JsonObject()
+			.put(VidIsolatorSchedulerConstants.TYPE, environment.getProperty(VidIsolatorSchedulerConstants.TYPE_VALUE))
+			.put(VidIsolatorSchedulerConstants.SECONDS, environment.getProperty(VidIsolatorSchedulerConstants.SECONDS_VALUE))
+			.put(VidIsolatorSchedulerConstants.MINUTES, environment.getProperty(VidIsolatorSchedulerConstants.MINUTES_VALUE))
+			.put(VidIsolatorSchedulerConstants.HOURS, environment.getProperty(VidIsolatorSchedulerConstants.HOURS_VALUE))
+			.put(VidIsolatorSchedulerConstants.DAY_OF_MONTH,
+				environment.getProperty(VidIsolatorSchedulerConstants.DAY_OF_MONTH_VALUE))
+			.put(VidIsolatorSchedulerConstants.MONTHS, environment.getProperty(VidIsolatorSchedulerConstants.MONTHS_VALUE))
+			.put(VidIsolatorSchedulerConstants.DAYS_OF_WEEK,
+				environment.getProperty(VidIsolatorSchedulerConstants.DAYS_OF_WEEK_VALUE));
+
+		eventBus.send(VidIsolatorSchedulerConstants.CHIME,
+			new JsonObject().put(VidIsolatorSchedulerConstants.OPERATION, VidIsolatorSchedulerConstants.OPERATION_VALUE)
+				.put(VidIsolatorSchedulerConstants.NAME, VidIsolatorSchedulerConstants.NAME_VALUE)
+				.put(VidIsolatorSchedulerConstants.DESCRIPTION, timer),
+			res -> {
+				if (res.succeeded()) {
+					LOGGER.info("VidIsolatorVerticle started");
+				} else if (res.failed()) {
+					LOGGER.error("VidIsolatorVerticle failed with cause ", res.cause());
+					vertx.close();
+				}
+			}
+		);
+	}
+}

--- a/kernel/kernel-idgenerator-service/src/main/resources/application-local.properties
+++ b/kernel/kernel-idgenerator-service/src/main/resources/application-local.properties
@@ -104,6 +104,20 @@ kernel.vid.revoke-scheduler-months=*
 #schedular weeks configuration
 kernel.vid.revoke-scheduler-days_of_week=*
 
+kernel.vid.isolator-scheduler-type=cron
+#schedular seconds configuration
+kernel.vid.isolator-scheduler-seconds=0
+#schedular minutes configuration
+kernel.vid.isolator-scheduler-minutes=0
+#schedular hours configuration
+kernel.vid.isolator-scheduler-hours=*
+#schedular days configuration
+kernel.vid.isolator-scheduler-days_of_month=*
+#schedular months configuration
+kernel.vid.isolator-scheduler-months=*
+#schedular weeks configuration
+kernel.vid.isolator-scheduler-days_of_week=*
+
 #-----------------------------UIN Properties--------------------------------------
 
 kernel.uin.transfer-scheduler-type=cron

--- a/kernel/kernel-idgenerator-service/src/test/java/io/mosip/kernel/vidgenerator/test/service/VidGeneratorServiceTest.java
+++ b/kernel/kernel-idgenerator-service/src/test/java/io/mosip/kernel/vidgenerator/test/service/VidGeneratorServiceTest.java
@@ -1,16 +1,25 @@
 package io.mosip.kernel.vidgenerator.test.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,8 +35,10 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import io.mosip.kernel.core.util.DateUtils;
 import io.mosip.kernel.idgenerator.config.HibernateDaoConfig;
 import io.mosip.kernel.vidgenerator.constant.VidLifecycleStatus;
+import io.mosip.kernel.vidgenerator.entity.VidAssignedEntity;
 import io.mosip.kernel.vidgenerator.entity.VidEntity;
 import io.mosip.kernel.vidgenerator.exception.VidGeneratorServiceException;
+import io.mosip.kernel.vidgenerator.repository.VidAssignedRepository;
 import io.mosip.kernel.vidgenerator.repository.VidRepository;
 import io.mosip.kernel.vidgenerator.service.VidService;
 
@@ -44,13 +55,30 @@ public class VidGeneratorServiceTest {
 	@MockBean
 	private VidRepository vidRepository;
 
-	private VidEntity assignedEntity;
+	@MockBean
+	private VidAssignedRepository vidAssignedRepository;
 
-	private List<VidEntity> assignedEntities;
+	private List<VidAssignedEntity> expiredButAssignedStatusVAEntities;
 
-	private VidEntity expiredEntity;
+	private List<VidAssignedEntity> notExpiredButAssignedStatusVAEntities;
 
-	private List<VidEntity> expiredEntities;
+	private List<VidAssignedEntity> renewableButExpiredStatusVAEntities;
+
+	private List<VidAssignedEntity> notRenewableButExpiredStatusVAEntities;
+
+	private List<VidEntity> nonExpiredButAssignedStatusEntities;
+
+	private List<VidEntity> expiredButAssignedStatusEntities;
+
+	@Captor
+	ArgumentCaptor<List<VidEntity>> vidEntityListCaptor;
+
+	@Captor
+	ArgumentCaptor<List<VidAssignedEntity>> vidAssignedEntityListCaptor;
+
+	@Captor
+	ArgumentCaptor<List<VidAssignedEntity>> vidAssignedEntityListCaptor2;
+
 
 	private VidEntity availableEntity;
 
@@ -60,20 +88,61 @@ public class VidGeneratorServiceTest {
 	public void init() {
 		availableEntityWithExpiry = new VidEntity("3650694284580734", VidLifecycleStatus.AVAILABLE, null);
 		availableEntity = new VidEntity("3650694284580734", VidLifecycleStatus.AVAILABLE, null);
-		assignedEntity = new VidEntity("3650694284580734", VidLifecycleStatus.ASSIGNED,
-				DateUtils.getUTCCurrentDateTime().minus(1, ChronoUnit.MONTHS));
-		assignedEntity.setCreatedBy("MOSIP_ADMIN");
-		assignedEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
-		assignedEntities = new ArrayList<>();
-		assignedEntities.add(assignedEntity);
-		expiredEntity = new VidEntity("3690694284580734", VidLifecycleStatus.EXPIRED,
-				DateUtils.getUTCCurrentDateTime().minus(7, ChronoUnit.MONTHS));
-		assignedEntity.setCreatedBy("MOSIP_ADMIN");
-		assignedEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
-		assignedEntity.setUpdatedBy("MOSIP_ADMIN");
-		assignedEntity.setUpdatedtimes(DateUtils.getUTCCurrentDateTime().minus(7, ChronoUnit.MONTHS));
-		expiredEntities = new ArrayList<>();
-		expiredEntities.add(expiredEntity);
+		
+		VidAssignedEntity expiredButAssignedStatusVAEntity = new VidAssignedEntity("3690694284580731", 
+			VidLifecycleStatus.ASSIGNED, DateUtils.getUTCCurrentDateTime().minusMinutes(30));
+		expiredButAssignedStatusVAEntity.setCreatedBy("MOSIP_ADMIN");
+		expiredButAssignedStatusVAEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusMonths(10));
+		expiredButAssignedStatusVAEntity.setUpdatedBy("MOSIP_ADMIN");
+		expiredButAssignedStatusVAEntity.setUpdatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
+		expiredButAssignedStatusVAEntities = new ArrayList<>();
+		expiredButAssignedStatusVAEntities.add(expiredButAssignedStatusVAEntity);
+
+		VidAssignedEntity notExpiredButAssignedStatusVAEntity = new VidAssignedEntity("3690694284580732", 
+			VidLifecycleStatus.ASSIGNED, DateUtils.getUTCCurrentDateTime().plusMinutes(30));
+		notExpiredButAssignedStatusVAEntity.setCreatedBy("MOSIP_ADMIN");
+		notExpiredButAssignedStatusVAEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusMonths(10));
+		notExpiredButAssignedStatusVAEntity.setUpdatedBy("MOSIP_ADMIN");
+		notExpiredButAssignedStatusVAEntity.setUpdatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
+		notExpiredButAssignedStatusVAEntities = new ArrayList<>();
+		notExpiredButAssignedStatusVAEntities.add(notExpiredButAssignedStatusVAEntity);
+
+		VidAssignedEntity renewableButExpiredStatusVAEntity = new VidAssignedEntity("3690694284580733", 
+			VidLifecycleStatus.EXPIRED, DateUtils.getUTCCurrentDateTime().minusMonths(7));
+		renewableButExpiredStatusVAEntity.setCreatedBy("MOSIP_ADMIN");
+		renewableButExpiredStatusVAEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusMonths(10));
+		renewableButExpiredStatusVAEntity.setUpdatedBy("MOSIP_ADMIN");
+		renewableButExpiredStatusVAEntity.setUpdatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
+		renewableButExpiredStatusVAEntities = new ArrayList<>();
+		renewableButExpiredStatusVAEntities.add(renewableButExpiredStatusVAEntity);
+
+		VidAssignedEntity notRenewableButExpiredStatusVAEntity = new VidAssignedEntity("3690694284580734", 
+			VidLifecycleStatus.EXPIRED, DateUtils.getUTCCurrentDateTime().minusMinutes(30));
+		notRenewableButExpiredStatusVAEntity.setCreatedBy("MOSIP_ADMIN");
+		notRenewableButExpiredStatusVAEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusMonths(10));
+		notRenewableButExpiredStatusVAEntity.setUpdatedBy("MOSIP_ADMIN");
+		notRenewableButExpiredStatusVAEntity.setUpdatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
+		notRenewableButExpiredStatusVAEntities = new ArrayList<>();
+		notRenewableButExpiredStatusVAEntities.add(notRenewableButExpiredStatusVAEntity);
+
+		VidEntity nonExpiredButAssignedStatusEntity = new VidEntity("3690694284580735", 
+			VidLifecycleStatus.ASSIGNED, DateUtils.getUTCCurrentDateTime().plusMinutes(30));
+		nonExpiredButAssignedStatusEntity.setCreatedBy("MOSIP_ADMIN");
+		nonExpiredButAssignedStatusEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusMonths(10));
+		nonExpiredButAssignedStatusEntity.setUpdatedBy("MOSIP_ADMIN");
+		nonExpiredButAssignedStatusEntity.setUpdatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
+		nonExpiredButAssignedStatusEntities = new ArrayList<>();
+		nonExpiredButAssignedStatusEntities.add(nonExpiredButAssignedStatusEntity);
+
+		VidEntity expiredButAssignedStatusEntity = new VidEntity("3690694284580736", 
+			VidLifecycleStatus.ASSIGNED, DateUtils.getUTCCurrentDateTime().minusMinutes(30));
+		expiredButAssignedStatusEntity.setCreatedBy("MOSIP_ADMIN");
+		expiredButAssignedStatusEntity.setCreatedtimes(DateUtils.getUTCCurrentDateTime().minusMonths(10));
+		expiredButAssignedStatusEntity.setUpdatedBy("MOSIP_ADMIN");
+		expiredButAssignedStatusEntity.setUpdatedtimes(DateUtils.getUTCCurrentDateTime().minusDays(10));
+		expiredButAssignedStatusEntities = new ArrayList<>();
+		expiredButAssignedStatusEntities.add(expiredButAssignedStatusEntity);
+
 	}
 
 	@Test(expected = VidGeneratorServiceException.class)
@@ -158,20 +227,47 @@ public class VidGeneratorServiceTest {
 
 	@Test
 	public void expireOrRenewTest() {
-		Mockito.when(vidRepository.findByStatusAndIsDeletedFalse(VidLifecycleStatus.ASSIGNED))
-				.thenReturn(assignedEntities);
-		Mockito.when(vidRepository.saveAll(assignedEntities)).thenReturn(assignedEntities);
-		Mockito.when(vidRepository.findByStatusAndIsDeletedFalse(VidLifecycleStatus.EXPIRED))
-				.thenReturn(expiredEntities);
-		Mockito.when(vidRepository.saveAll(expiredEntities)).thenReturn(expiredEntities);
+		Mockito.when(vidAssignedRepository.findByStatusAndIsDeletedFalse(VidLifecycleStatus.ASSIGNED))
+			.thenReturn(Stream.of(expiredButAssignedStatusVAEntities, notExpiredButAssignedStatusVAEntities)
+				.flatMap(Collection::stream)
+				.collect(Collectors.toList()));
+		Mockito.when(vidAssignedRepository.saveAll(vidAssignedEntityListCaptor.capture()))
+			.thenAnswer(i -> StreamSupport.stream((
+				(List<VidAssignedEntity>) i.getArguments()[0]).spliterator(), false)
+				.collect(Collectors.toList()));
+		
+		Mockito.when(vidAssignedRepository.findByStatusAndIsDeletedFalse(VidLifecycleStatus.EXPIRED))
+			.thenReturn(Stream.of(renewableButExpiredStatusVAEntities, notRenewableButExpiredStatusVAEntities)
+				.flatMap(Collection::stream)
+				.collect(Collectors.toList()));
+		Mockito.when(vidRepository.saveAll(vidEntityListCaptor.capture()))
+			.thenAnswer(i -> StreamSupport.stream((
+				(List<VidEntity>) i.getArguments()[0]).spliterator(), false)
+				.collect(Collectors.toList()));
 		vidService.expireAndRenew();
-		for (VidEntity vidEntity : assignedEntities) {
-			assertThat(vidEntity.getStatus(), is(VidLifecycleStatus.EXPIRED));
-		}
-		for (VidEntity vidEntity : expiredEntities) {
-			assertThat(vidEntity.getStatus(), is(VidLifecycleStatus.AVAILABLE));
-			assertNull(vidEntity.getVidExpiry());
-		}
+		Mockito.verify(vidAssignedRepository).deleteAll(vidAssignedEntityListCaptor2.capture());
+
+		List<String> expiredButAssignedStatusVids = expiredButAssignedStatusVAEntities.stream()
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		List<String> expiredStatusVids = vidAssignedEntityListCaptor.getValue().stream()
+			.filter(item -> item.getStatus().equals(VidLifecycleStatus.EXPIRED))
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		assertEquals(expiredButAssignedStatusVids, expiredStatusVids);
+
+		List<String> renewableButExpiredStatusVids = renewableButExpiredStatusVAEntities.stream()
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		List<String> deletedVids = vidAssignedEntityListCaptor2.getValue().stream()
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		List<String> renewedVids = vidEntityListCaptor.getValue().stream()
+			.filter(item -> item.getStatus().equals(VidLifecycleStatus.AVAILABLE))
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		assertEquals(renewableButExpiredStatusVids, deletedVids);
+		assertEquals(renewableButExpiredStatusVids, renewedVids);
 	}
 
 	@Test
@@ -193,14 +289,50 @@ public class VidGeneratorServiceTest {
 	@Test
 	public void saveVIDTest() {
 		Mockito.when(vidRepository.existsById(availableEntity.getVid())).thenReturn(false);
+		Mockito.when(vidAssignedRepository.existsById(availableEntity.getVid())).thenReturn(false);
 		Mockito.when(vidRepository.saveAndFlush(availableEntity)).thenReturn(availableEntity);
 		assertThat(vidService.saveVID(availableEntity), is(true));
 	}
 
 	@Test
-	public void saveVIDFalseTest() {
+	public void saveVIDFalseTest1() {
 		Mockito.when(vidRepository.existsById(availableEntity.getVid())).thenReturn(true);
+		Mockito.when(vidAssignedRepository.existsById(availableEntity.getVid())).thenReturn(false);
 		assertThat(vidService.saveVID(availableEntity), is(false));
 	}
 
+	@Test
+	public void saveVIDFalseTest2() {
+		Mockito.when(vidRepository.existsById(availableEntity.getVid())).thenReturn(false);
+		Mockito.when(vidAssignedRepository.existsById(availableEntity.getVid())).thenReturn(true);
+		assertThat(vidService.saveVID(availableEntity), is(false));
+	}
+
+	@Test
+	public void isolateAssignedVidTest() {
+		List<VidEntity> validTranserEntities = 
+			Stream.of(nonExpiredButAssignedStatusEntities, expiredButAssignedStatusEntities)
+				.flatMap(Collection::stream)
+				.collect(Collectors.toList());
+		Mockito.when(vidRepository.findByStatusAndIsDeletedFalse(VidLifecycleStatus.ASSIGNED))
+			.thenReturn(validTranserEntities);
+		Mockito.when(vidAssignedRepository.saveAll(vidAssignedEntityListCaptor.capture()))
+			.thenAnswer(i -> StreamSupport.stream((
+				(List<VidAssignedEntity>) i.getArguments()[0]).spliterator(), false)
+				.collect(Collectors.toList()));
+		vidService.isolateAssignedVids();
+		Mockito.verify(vidRepository).deleteAll(vidEntityListCaptor.capture());
+		List<String> validTranserVids = validTranserEntities.stream()
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		List<String> vidAssignedEntityVids = vidAssignedEntityListCaptor.getValue().stream()
+			.filter(item -> item.getStatus().equals(VidLifecycleStatus.ASSIGNED))
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		List<String> vidEntityVids = vidEntityListCaptor.getValue().stream()
+			.flatMap(item -> Stream.of(item.getVid()))
+			.collect(Collectors.toList());
+		assertEquals(validTranserVids, vidAssignedEntityVids);
+		assertEquals(validTranserVids, vidEntityVids);
+	}
 }


### PR DESCRIPTION
Changes:
1.  New verticle created with cron job to isolate assigned vids to a new table at regular intervals
2.  Return statement added to VidFetcherRouter to avoid assignment of vids on error situations