### PR TITLE
MOSIP-11056 : Vid renewal feature replaced with Vid release to avoid guessing attacks

### DIFF
--- a/kernel/kernel-idgenerator-service/README.md
+++ b/kernel/kernel-idgenerator-service/README.md
@@ -105,8 +105,8 @@ mosip.kernel.crypto.sign-algorithm-name=RS256
 mosip.kernel.vid.min-unused-threshold=100000
 #number of vids to generate
 mosip.kernel.vid.vids-to-generate=200000
-#time to renew after expiry(in days)
-mosip.kernel.vid.time-to-renew-after-expiry=5
+#time to release after expiry(in days)
+mosip.kernel.vid.time-to-release-after-expiry=5
 #for genaration on init vids timeout 
 mosip.kernel.vid.pool-population-timeout=10000000
 

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/service/VidService.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/service/VidService.java
@@ -11,7 +11,7 @@ public interface VidService {
 
 	long fetchVidCount(String status);
 
-	void expireAndRenew();
+	void expireAndRelease();
 
 	boolean saveVID(VidEntity vid);
 

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidExpiryVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidExpiryVerticle.java
@@ -55,7 +55,7 @@ public class VidExpiryVerticle extends AbstractVerticle {
 		MessageConsumer<JsonObject> consumer = eventBus.consumer(VidSchedulerConstants.NAME_VALUE);
 
 		// handle chime event
-		consumer.handler(message -> vidService.expireAndRenew());
+		consumer.handler(message -> vidService.expireAndRelease());
 
 		JsonObject timer = new JsonObject()
 				.put(VidSchedulerConstants.TYPE, environment.getProperty(VidSchedulerConstants.TYPE_VALUE))

--- a/kernel/kernel-idgenerator-service/src/main/resources/application-local.properties
+++ b/kernel/kernel-idgenerator-service/src/main/resources/application-local.properties
@@ -83,8 +83,8 @@ mosip.kernel.crypto.sign-algorithm-name=RS256
 mosip.kernel.vid.min-unused-threshold=5
 #number of vids to generate
 mosip.kernel.vid.vids-to-generate=10
-#time to renew after expiry(in month)
-mosip.kernel.vid.time-to-renew-after-expiry=5
+#time to release after expiry(in days)
+mosip.kernel.vid.time-to-release-after-expiry=5
 #for genaration on init vids timeout 
 mosip.kernel.vid.pool-population-timeout=1000000
 

--- a/kernel/kernel-idgenerator-service/src/test/resources/application-test.properties
+++ b/kernel/kernel-idgenerator-service/src/test/resources/application-test.properties
@@ -88,8 +88,8 @@ mosip.kernel.crypto.sign-algorithm-name=RS256
 mosip.kernel.vid.min-unused-threshold=5
 #number of vids to generate
 mosip.kernel.vid.vids-to-generate=10
-#time to renew after expiry(in month)
-mosip.kernel.vid.time-to-renew-after-expiry=5
+#time to release after expiry(in days)
+mosip.kernel.vid.time-to-release-after-expiry=5
 #for genaration on init vids timeout 
 mosip.kernel.vid.pool-population-timeout=1000000
 


### PR DESCRIPTION
Because of vid renewal feature, it is possible for guessing the next assigning vids, so to resolve this we are releasing the vids instead, this allows the same vid to be randomly generated later.