### PR TITLE
MOSIP-11072 : Order of reloading activity is changed to avoid No installed provider exception

### DIFF
--- a/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanager/hsm/impl/KeyStoreImpl.java
+++ b/kernel/kernel-keymanager-service/src/main/java/io/mosip/kernel/keymanager/hsm/impl/KeyStoreImpl.java
@@ -420,10 +420,12 @@ public class KeyStoreImpl implements io.mosip.kernel.core.keymanager.spi.KeyStor
 					PROVIDER_ALLOWED_RELOAD_INTERVEL_IN_SECONDS + " sec");
 			return;
 		}
-		if (Objects.nonNull(provider)) {
-			Security.removeProvider(provider.getName());
-		}
+		String existingProviderName = null;
+		if (Objects.nonNull(provider))
+			existingProviderName = provider.getName();
 		provider = setupProvider(configPath);
+		if(existingProviderName != null)
+			Security.removeProvider(existingProviderName);
 		addProvider(provider);
 		this.keyStore = getKeystoreInstance(keystoreType, provider);
 		loadKeystore();

--- a/kernel/kernel-keymanager-service/src/test/java/io/mosip/kernel/keymanager/hsm/test/KeyStoreImplExceptionTest.java
+++ b/kernel/kernel-keymanager-service/src/test/java/io/mosip/kernel/keymanager/hsm/test/KeyStoreImplExceptionTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import io.mosip.kernel.core.keymanager.exception.KeystoreProcessingException;
 import io.mosip.kernel.core.keymanager.exception.NoSuchSecurityProviderException;
+import io.mosip.kernel.core.util.DateUtils;
 import io.mosip.kernel.keymanager.hsm.impl.KeyStoreImpl;
 
 @RunWith(SpringRunner.class)
@@ -52,6 +53,8 @@ public class KeyStoreImplExceptionTest {
 		ReflectionTestUtils.setField(keyStoreImpl, "organizationalUnit", "organizationalUnit");
 		ReflectionTestUtils.setField(keyStoreImpl, "organization", "organization");
 		ReflectionTestUtils.setField(keyStoreImpl, "country", "country");
+		ReflectionTestUtils.setField(keyStoreImpl, "lastProviderLoadedTime", 
+			DateUtils.getUTCCurrentDateTime().minusMinutes(10));
 		keyStore.load(null);
 		provider = new BouncyCastleProvider();
 		Security.addProvider(provider);


### PR DESCRIPTION
Changes:
1. First setup of provider is completed and then provider is uninstalled in reloading activity
2. Unit test cases changes to handle lastProviderLoadedTime changes 