### PR TITLE
MOSIP-11192 : Ceylon libraries are bundled to avoid downloading at runtime

### DIFF
--- a/kernel/kernel-idgenerator-service/Dockerfile
+++ b/kernel/kernel-idgenerator-service/Dockerfile
@@ -71,12 +71,20 @@ USER ${container_user_uid}:${container_user_gid}
 
 EXPOSE 8080
 
-CMD if [ "$is_glowroot_env" = "present" ]; then \
-    wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
+#Below 4 lines is added only as a temporary fix to downloaded the ceylon dependencies for chime scheduler
+#later this chime to be replaced with something else
+CMD apt-get update && apt-get install -y unzip ; \
+    wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/regproc-reprocessor-ceylon-cache-repo.zip ; \
+    unzip regproc-reprocessor-ceylon-cache-repo.zip ; \
+    rm -rf regproc-reprocessor-ceylon-cache-repo.zip ; \
+
+    if [ "$is_glowroot_env" = "present" ]; then \
+    wget -q --show-progress "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
     unzip glowroot.zip ; \
     rm -rf glowroot.zip ; \
+
     sed -i 's/<service_name>/kernel-idgenerator-service/g' glowroot/glowroot.properties ; \
-    java -jar -javaagent:glowroot/glowroot.jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" -XX:HeapDumpPath=/home/  kernel-idgenerator-service.jar ; \
+    java -jar -javaagent:glowroot/glowroot.jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" -XX:HeapDumpPath=/home/ -Dceylon.cache.repo=./regproc-reprocessor-ceylon-cache-repo kernel-idgenerator-service.jar ; \
     else \
-    java -jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" kernel-idgenerator-service.jar ; \
+    java -jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" -Dceylon.cache.repo=./regproc-reprocessor-ceylon-cache-repo kernel-idgenerator-service.jar ; \
     fi


### PR DESCRIPTION
The ssl certificate of ceylon is also renewed in the mid of December possibily causing "javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target". Anyways we should avoid download, so downloading the bundled library on restart of pod.