### PR TITLE
MOSIP-11192 : A new config added as a patch to skip reuse of JWT token from security context

### DIFF
--- a/kernel/kernel-idgenerator-service/src/main/resources/bootstrap.properties
+++ b/kernel/kernel-idgenerator-service/src/main/resources/bootstrap.properties
@@ -24,4 +24,8 @@ server.servlet.path=/v1/idgenerator
 # 5 minutes (should not be done in production)
 #health.config.enabled=false
 
+# This config is introduced as a patch to fix the use of expired token from security context 
+# rather than taking token from actual request. This config is set in bootstrap file to change the 
+# default behavior only for this app
+auth.adapter.rest.template.skip.context.token.reuse=true
 


### PR DESCRIPTION
Problem:
In RestTemplateInterceptor JWT token is taken from spring security context if available, this is done to avoid setting the JWT token explictly while making consecutive rest calls while processing the same request.
But In case of vertx applications, since it uses single thread to process multiple requests, the security context was sharing the JWT token between requests.

Solution:
Proper solution will be to use the vertx routing context in case of vertx applications.
Since the auth adapter is used in multiple apps, to keep the minimum impact of the changes done, a new config is introduced as a patch fix.

Changes:
1. New config introduced with default value to skip the resue of token from spring security context
2. Id generator service bootstrap file added with the new config and set to true to change the behavior only for this app