### PR TITLE
MOSIP-12699 : fixed idschema validation issue (#732)

### DIFF
--- a/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/impl/PacketReaderImpl.java
+++ b/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/impl/PacketReaderImpl.java
@@ -145,7 +145,7 @@ public class PacketReaderImpl implements IPacketReader {
 								finalMap.putIfAbsent(key,
 										value != null ? JsonUtils.javaObjectToJsonString(currentIdMap.get(key)) : null);
 							} catch (io.mosip.kernel.core.util.exception.JsonProcessingException e) {
-								e.printStackTrace();
+								LOGGER.error(ExceptionUtils.getStackTrace(e));
 								throw new GetAllIdentityException(e.getMessage());
 							}
 						}


### PR DESCRIPTION
* MOSIP-11634 : making BiometricRecord object serializable to cache using hazelcast (#716)

Co-authored-by: Monobikash Das <M1045447@mindtree.com>

* MOSIP-12259 : fixed schema validation issue (#717)

* MOSIP-11634 : making BiometricRecord object serializable to cache using hazelcast

* MOSIP-12259 : fixed schema validation issue

Co-authored-by: Monobikash Das <M1045447@mindtree.com>

* MOSIP-12699 : fixed idschema validation issue

* MOSIP-12699 : fixed idschema validation issue

Co-authored-by: Monobikash Das <M1045447@mindtree.com>