### PR TITLE
Removed BDB validation if exception is true

### DIFF
--- a/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/util/PacketManagerHelper.java
+++ b/commons-packet/commons-packet-manager/src/main/java/io/mosip/commons/packet/util/PacketManagerHelper.java
@@ -63,25 +63,20 @@ public class PacketManagerHelper {
 
 
     public byte[] getXMLData(BiometricRecord biometricRecord, boolean offlineMode) throws Exception {
-        byte[] xmlBytes = null;
-        if (offlineMode) {
-            try (InputStream xsd = getClass().getClassLoader().getResourceAsStream(PacketManagerConstants.CBEFF_SCHEMA_FILE_PATH)) {
-                CbeffContainerImpl cbeffContainer = new CbeffContainerImpl();
-                List<BIR> birList = new ArrayList<>();
-                biometricRecord.getSegments().forEach(s -> birList.add(convertToBIR(s)));
-				BIR bir = cbeffContainer.createBIRType(birList);
-                xmlBytes = CbeffValidator.createXMLBytes(bir, IOUtils.toByteArray(xsd));
-            }
-        } else {
-            try (InputStream xsd = new URL(configServerFileStorageURL + schemaName).openStream()) {
-                CbeffContainerImpl cbeffContainer = new CbeffContainerImpl();
-                List<BIR> birList = new ArrayList<>();
-                biometricRecord.getSegments().forEach(s -> birList.add(convertToBIR(s)));
-				BIR bir = cbeffContainer.createBIRType(birList);
-                xmlBytes = CbeffValidator.createXMLBytes(bir, IOUtils.toByteArray(xsd));
-            }
-        }
-        return xmlBytes;
+    	
+    	try (InputStream xsd = offlineMode ? getClass().getClassLoader().getResourceAsStream(PacketManagerConstants.CBEFF_SCHEMA_FILE_PATH)
+         		: new URL(configServerFileStorageURL + schemaName).openStream()) {
+
+         	/** Removed this code as with latest cbeff validator, directly pass the BIR  No conversion required*/
+    		 //TODO after review needs to be removed
+//                 CbeffContainerImpl cbeffContainer = new CbeffContainerImpl();
+//                 List<BIR> birList = new ArrayList<>();
+//                 biometricRecord.getSegments().forEach(s -> birList.add(convertToBIR(s)));
+//                 BIRType bir = cbeffContainer.createBIRType(birList);
+//                 xmlBytes = CbeffValidator.createXMLBytes(bir, IOUtils.toByteArray(xsd));
+
+             return io.mosip.kernel.biometrics.commons.CbeffValidator.createXMLBytes(biometricRecord.getSegments(), IOUtils.toByteArray(xsd));
+           }
     }
 
     public static byte[] generateHash(List<String> order, Map<String, byte[]> data) throws IOException, NoSuchAlgorithmException {

--- a/kernel/kernel-biometrics-api/src/main/java/io/mosip/kernel/biometrics/commons/CbeffValidator.java
+++ b/kernel/kernel-biometrics-api/src/main/java/io/mosip/kernel/biometrics/commons/CbeffValidator.java
@@ -60,7 +60,8 @@ public class CbeffValidator {
 		List<BIR> birList = birRoot.getBirs();
 		for (BIR bir : birList) {
 			if (bir != null) {
-				if (bir.getBdb().length < 1) {
+				if ((bir.getBdb()==null || bir.getBdb().length < 1)
+						&& (bir.getOthers()==null || bir.getOthers().get("EXCEPTION").equals(false))) {
 					throw new CbeffException("BDB value can't be empty");
 				}
 				if (bir.getBdbInfo() != null) {
@@ -147,7 +148,36 @@ public class CbeffValidator {
 	 * 
 	 */
 	public static byte[] createXMLBytes(BIR bir, byte[] xsd) throws Exception {
+		
 		CbeffValidator.validateXML(bir);
+		
+		return getSavedData(bir, xsd);
+	}
+	
+	/**
+	 * Method used for creating XML bytes using JAXB
+	 * 
+	 * @param birs list of bir's need to be added in xsd
+	 * @param xsd xml schema definition
+	 * @return byte[] byte array of XML data
+	 * 
+	 * @exception Exception exception
+	 * 
+	 */
+	public static byte[] createXMLBytes(List<BIR> birs, byte[] xsd) throws Exception {
+		
+		BIR capturedBIR = birs.get(0);
+		
+		BIR parentBIR = new BIR.BIRBuilder().withBirInfo(capturedBIR.getBirInfo())
+		.withVersion(capturedBIR.getVersion())
+		.withCbeffversion(capturedBIR.getCbeffversion())
+		.build();
+		
+		parentBIR.setBirs(birs);
+		return createXMLBytes(parentBIR, xsd);
+	}
+
+	private static byte[] getSavedData(BIR bir, byte[] xsd) throws Exception {
 		JAXBContext jaxbContext = JAXBContext.newInstance(BIR.class);
 		Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
 		jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE); // To


### PR DESCRIPTION
1. Overloaded createXmlBytes method with arg list of BIRS.
2. Removed BDB validation if exception is true in CBEFF Validator
