### PR TITLE
[MOSIP-34747] - set spring.profiles.active composite (#1553)

### DIFF
--- a/deploy/copy_cm.sh
+++ b/deploy/copy_cm.sh
@@ -3,7 +3,7 @@
 # DST_NS: Destination namespace 
 
 function copying_cm() {
-  UTIL_URL=https://github.com/mosip/mosip-infra/blob/master/deployment/v3/utils/copy_cm_func.sh
+  UTIL_URL=https://raw.githubusercontent.com/mosip/mosip-infra/master/deployment/v3/utils/copy_cm_func.sh
   COPY_UTIL=./copy_cm_func.sh
   DST_NS=kernel
 

--- a/kernel/kernel-applicanttype-api/pom.xml
+++ b/kernel/kernel-applicanttype-api/pom.xml
@@ -69,7 +69,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-authcodeflowproxy-api/pom.xml
+++ b/kernel/kernel-authcodeflowproxy-api/pom.xml
@@ -26,7 +26,7 @@
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
 
 		<!-- spring -->
-		<spring.boot.version>2.0.2.RELEASE</spring.boot.version>
+		<spring.boot.version>3.1.9</spring.boot.version>
 		<spring.data.jpa.version>2.0.7.RELEASE</spring.data.jpa.version>
 		<spring.security.test.version>5.0.5.RELEASE</spring.security.test.version>
 		<spring-cloud-config.version>2.0.4.RELEASE</spring-cloud-config.version>
@@ -131,7 +131,7 @@
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
 
 		<!-- spring -->
-		<spring.boot.version>2.0.2.RELEASE</spring.boot.version>
+		<spring.boot.version>3.1.9</spring.boot.version>
 		<spring.data.jpa.version>2.0.7.RELEASE</spring.data.jpa.version>
 		<spring.security.test.version>5.0.5.RELEASE</spring.security.test.version>
 		<spring-cloud-config.version>2.0.4.RELEASE</spring-cloud-config.version>
@@ -238,7 +238,7 @@
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>jwks-rsa</artifactId>
-			<version>0.18.0</version>
+			<version>0.22.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
@@ -281,7 +281,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-bioapi-provider/pom.xml
+++ b/kernel/kernel-bioapi-provider/pom.xml
@@ -265,7 +265,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-biometrics-api/pom.xml
+++ b/kernel/kernel-biometrics-api/pom.xml
@@ -276,7 +276,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-bom/pom.xml
+++ b/kernel/kernel-bom/pom.xml
@@ -34,7 +34,7 @@
 		
 		<aspectjweaver-version>1.9.21.2</aspectjweaver-version>
 
-		<apache.httpcomponents.version>4.5.6</apache.httpcomponents.version>
+		<apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
 		
 		<vertx.version>3.9.13</vertx.version>
 		<hazelcast-version>3.9.4</hazelcast-version>
@@ -46,7 +46,7 @@
 				
 		<powermock.version>2.0.9</powermock.version>
 		
-		<json.version>20180813</json.version>
+		<json.version>20231013</json.version>
 		<json-simple-version>1.1.1</json-simple-version>
 		<io.jsonwebtoken.jjwt.version>0.6.0</io.jsonwebtoken.jjwt.version>
 		<commons-collections.version>3.2.2</commons-collections.version>

--- a/kernel/kernel-config-server/Dockerfile
+++ b/kernel/kernel-config-server/Dockerfile
@@ -59,7 +59,7 @@ LABEL build_time=${BUILD_TIME}
 
 # install packages and create user
 RUN apt-get -y update \
-&& apt-get install -y unzip sudo\
+&& apt-get install -y unzip sudo git \
 && groupadd -g ${container_user_gid} ${container_user_group} \
 && useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
 && usermod -aG sudo ${container_user} \

--- a/kernel/kernel-config-server/README.md
+++ b/kernel/kernel-config-server/README.md
@@ -24,34 +24,52 @@ For more information look [here]( https://cloud.spring.io/spring-cloud-config/si
 **How To Run**
 <br/>
 To run the application: <br/>
-Make sure you have configured ssh keys to connect to git, because it will take ssh keys from default location (${user.home}/.ssh) . 
+Make sure you have configured ssh keys to connect to git, because it will take ssh keys from default location (${user.home}/.ssh) .
+
+Set environment variables to support git repos for composite profile. Here 0,1 indicates list items.
+If any property exists in multiple repositories then repo at 0 index will have high priority and value will be referred from that repo.
+```
+export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI=<git-repo-ssh-url>
+export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=git
+export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_DEFAULT_LABEL=<branch-to-refer>
+
+export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_URI=<git-repo-ssh-url>
+export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_TYPE=git
+export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_DEFAULT_LABEL=<branch-to-refer>
+```
 Now run the jar using the following command: <br/>
 <br/>
-`java -jar -Dspring.cloud.config.server.git.uri=< git-repo-ssh-url > -Dspring.cloud.config.server.git.search-paths=< config-folder-location-in-git-repo > -Dencrypt.keyStore.location=file:///< file-location-of-keystore > -Dencrypt.keyStore.password=< keystore-passowrd > -Dencrypt.keyStore.alias=< keystore-alias > -Dencrypt.keyStore.secret=< keystore-secret > < jar-name >`
+`java -jar -Dencrypt.keyStore.location=file:///< file-location-of-keystore > -Dencrypt.keyStore.password=< keystore-passowrd > -Dencrypt.keyStore.alias=< keystore-alias > -Dencrypt.keyStore.secret=< keystore-secret > < jar-name >`
 <br/>
 <br/>
-To run it inside Docker container provide the follwing run time arguments:
-1. git_url_env 
+To run it inside Docker container provide the following run time arguments:
+1. SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI 
 The URL of your Git repo
 
-2. git_config_folder_env
+2. SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE
+Repo type, which is git
+
+3. SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_DEFAULT_LABEL
+branch to refer in git repo. If not provided, it will default to `main` branch
+
+4. SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_SEARCH_PATHS
 The folder inside your git repo which contains the configuration
 
-3. encrypt_keyStore_location_env
+5. encrypt_keyStore_location_env
 The encrypt keystore location 
 
-4. encrypt_keyStore_password_env
+6. encrypt_keyStore_password_env
 The encryption keystore password
 
-5. encrypt_keyStore_alias_env
+7. encrypt_keyStore_alias_env
 The encryption keystore alias
 
-6. encrypt_keyStore_secret_env
+8. encrypt_keyStore_secret_env
 The encryption keyStore secret
 
 The final docker run command should look like:
 
-`docker run --name=<name-the-container> -d -v <location-of-encrypt-keystore>/server.keystore:<mount-keystore-location-inside-container>/server.keystore:z -v /home/madmin/<location of folder containing git ssh keys>:<mount-ssh-location-inside-container>/.ssh:z -e git_url_env=<git_ssh_url_env> -e git_config_folder_env=<git_config_folder_env> -e encrypt_keyStore_location_env=file:///<mount-keystore-location-inside-container>/server.keystore -e encrypt_keyStore_password_env=<encrypt_keyStore_password_env> -e encrypt_keyStore_alias_env=<encrypt_keyStore_alias_env> -e encrypt_keyStore_secret_env=<encrypt_keyStore_secret_env> -p 51000:51000 <name-of-docker-image-you-built>`
+`docker run --name=<name-the-container> -d -v <location-of-encrypt-keystore>/server.keystore:<mount-keystore-location-inside-container>/server.keystore:z -v /home/madmin/<location of folder containing git ssh keys>:<mount-ssh-location-inside-container>/.ssh:z -e SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI=<git_ssh_url_env> -e SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=git -e SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_DEFAULT_LABEL=<branch-for-repo> -e encrypt_keyStore_location_env=file:///<mount-keystore-location-inside-container>/server.keystore -e encrypt_keyStore_password_env=<encrypt_keyStore_password_env> -e encrypt_keyStore_alias_env=<encrypt_keyStore_alias_env> -e encrypt_keyStore_secret_env=<encrypt_keyStore_secret_env> -p 51000:51000 <name-of-docker-image-you-built>`
 <br/>
 <br/>
 **To Encrypt any property:** <br/>
@@ -78,38 +96,39 @@ server.port = 51000
 #adding context path
 server.servlet.path=/config
 
-# Uncomment spring.cloud.config.server.git.uri and spring.cloud.config.server.git.search-paths for # connecting to git Repo for configuration.
-#################################################################
-#Git repository location where configuration files are stored
-#spring.cloud.config.server.git.uri=<your-git-repository-URL>
-
-#Path inside the GIT repo where config files are stored, in our case they are inside config directory
-#spring.cloud.config.server.git.search-paths=<folder-in-git-repository-containing-configuration>
-
-# Uncomment spring.profiles.active and spring.cloud.config.server.native.search-locations for     # connecting to local file system for configuration.
-#################################################################
-# spring.profiles.active=native
-
-# spring.cloud.config.server.native.search-locations=file:///<config-location-on-your-system>
+spring.profiles.active=composite
 
 #Server would return a HTTP 404 status, if the application is not found.By default, this flag is set to true.
 spring.cloud.config.server.accept-empty=false
 
-#Spring Cloud Config Server makes a clone of the remote git repository and if somehow the local copy gets 
+## As spring.profiles.active is composite, use env variable to provide values for git configuration as below
+##########################
+##Git repository location where configuration files are stored
+# SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI=<your-git-repository-URL>
+
+##Type of repository, possible types are git, svn, native
+# SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=git
+
+##Branch/label to refer for in config repository
+# SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_DEFAULT_LABEL=<your-git-repository-branch>
+
+#Spring Cloud Config Server makes a clone of the remote git repository and if somehow the local copy gets
 #dirty (e.g. folder content changes by OS process) so Spring Cloud Config Server cannot update the local copy
 #from remote repository. For Force-pull in such case, we are setting the flag to true.
-spring.cloud.config.server.git.force-pull=true
+# SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_FORCE_PULL=true
+
+# Setting up refresh rate to 5 seconds so that config server will check for updates in Git repo after every one minute,
+#can be lowered down for production.
+# SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_REFRESH_RATE=5
+
+# adding provision to clone on start of server instead of first request
+# SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_CLONE_ON_START=true
+
+#Path inside the GIT repo where config files are stored, in our case they are inside config directory
+#SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_SEARCH_PATHS=<folder-in-git-repository-containing-configuration>
 
 # Disabling health endpoints to improve performance of config server while in development, can be commented out in production.
 health.config.enabled=false
-
-# Setting up refresh rate to 1 minute so that config server will check for updates in Git repo after every one minute,
-#can be lowered down for production.
-spring.cloud.config.server.git.refreshRate=60
-
-
-# adding provision to clone on start of server instead of first request
-spring.cloud.config.server.git.cloneOnStart=true
 
 #For encryption of properties
 ###########################################
@@ -148,7 +167,7 @@ spring.cloud.config.uri=http://<config-host-url>:<config-port>
 spring.cloud.config.label=<git-branch>
 spring.application.name=<application-name>
 spring.cloud.config.name=<property-file-to-pick-up-configuration-from>
-spring.profiles.active=<active-profile>
+spring.profiles.active=composite
 management.endpoints.web.exposure.include=refresh
 #management.security.enabled=false
 
@@ -156,4 +175,27 @@ management.endpoints.web.exposure.include=refresh
 # 5 minutes (should not be done in production)
 spring.cloud.config.server.health.enabled=false
 
+```
+
+**cloud config supported for git type repository**
+
+```
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI=<your-git-repository-URL>
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=git
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_DEFAULT_LABEL=<your-git-repository-branch>
+```
+
+**cloud config supported for svn type repository**
+
+```
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI=<your-svn-repository-URL>
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=git
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_DEFAULT_LABEL=<your-svn-repository-branch>
+```
+
+**cloud config supported for native**
+
+```
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI=<file-path-for-local-properties>
+SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=native
 ```

--- a/kernel/kernel-config-server/pom.xml
+++ b/kernel/kernel-config-server/pom.xml
@@ -112,7 +112,7 @@
                <plugin>
                   <groupId>org.sonatype.plugins</groupId>
                   <artifactId>nexus-staging-maven-plugin</artifactId>
-                  <version>1.6.7</version>
+                  <version>1.6.14</version>
                   <extensions>true</extensions>
                   <executions>
                     <execution>

--- a/kernel/kernel-config-server/src/main/resources/bootstrap.properties
+++ b/kernel/kernel-config-server/src/main/resources/bootstrap.properties
@@ -41,4 +41,3 @@ health.config.enabled=false
 #encrypt.keyStore.secret=<your-encryption-keyStore-secret>
 
 mosip.config.dnd.services={'consul','kernel-config-service'}
-

--- a/kernel/kernel-config-server/src/main/resources/bootstrap.properties
+++ b/kernel/kernel-config-server/src/main/resources/bootstrap.properties
@@ -22,30 +22,15 @@ server.servlet.context-path=${server.servlet.path}
 #Path inside the GIT repo where config files are stored, in our case they are inside config directory
 #spring.cloud.config.server.git.search-paths=<folder-in-git-repository-containing-configuration>
 
-# Uncomment spring.profiles.active and spring.cloud.config.server.native.search-locations for     # connecting to local file system for configuration.
-#################################################################
-#spring.profiles.active=native
-
-#spring.cloud.config.server.native.search-locations=file:///<config-location-on-your-system>
+#support for composite property.
+#use env variables to provide list of repos.
+spring.profiles.active=composite
 
 #Server would return a HTTP 404 status, if the application is not found.By default, this flag is set to true.
 spring.cloud.config.server.accept-empty=false
 
-#Spring Cloud Config Server makes a clone of the remote git repository and if somehow the local copy gets 
-#dirty (e.g. folder content changes by OS process) so Spring Cloud Config Server cannot update the local copy
-#from remote repository. For Force-pull in such case, we are setting the flag to true.
-spring.cloud.config.server.git.force-pull=true
-
 # Disabling health endpoints to improve performance of config server while in development, can be commented out in production.
 health.config.enabled=false
-
-# Setting up refresh rate to 5 seconds so that config server will check for updates in Git repo after every one minute,
-#can be lowered down for production.
-spring.cloud.config.server.git.refreshRate=5
-
-
-# adding provision to clone on start of server instead of first request
-spring.cloud.config.server.git.cloneOnStart=true
 
 #For encryption of properties
 ###########################################

--- a/kernel/kernel-core/pom.xml
+++ b/kernel/kernel-core/pom.xml
@@ -285,7 +285,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-dataaccess-hibernate/pom.xml
+++ b/kernel/kernel-dataaccess-hibernate/pom.xml
@@ -89,7 +89,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-datamapper-orika/pom.xml
+++ b/kernel/kernel-datamapper-orika/pom.xml
@@ -70,7 +70,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-demographics-api/pom.xml
+++ b/kernel/kernel-demographics-api/pom.xml
@@ -177,7 +177,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-machineid/pom.xml
+++ b/kernel/kernel-idgenerator-machineid/pom.xml
@@ -87,7 +87,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-mispid/pom.xml
+++ b/kernel/kernel-idgenerator-mispid/pom.xml
@@ -91,7 +91,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-partnerid/pom.xml
+++ b/kernel/kernel-idgenerator-partnerid/pom.xml
@@ -89,7 +89,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-prid/pom.xml
+++ b/kernel/kernel-idgenerator-prid/pom.xml
@@ -94,7 +94,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-regcenterid/pom.xml
+++ b/kernel/kernel-idgenerator-regcenterid/pom.xml
@@ -89,7 +89,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-rid/pom.xml
+++ b/kernel/kernel-idgenerator-rid/pom.xml
@@ -89,7 +89,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-service/pom.xml
+++ b/kernel/kernel-idgenerator-service/pom.xml
@@ -214,7 +214,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-tokenid/pom.xml
+++ b/kernel/kernel-idgenerator-tokenid/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idgenerator-vid/pom.xml
+++ b/kernel/kernel-idgenerator-vid/pom.xml
@@ -64,7 +64,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idobjectvalidator/pom.xml
+++ b/kernel/kernel-idobjectvalidator/pom.xml
@@ -14,7 +14,7 @@
 		<kernel.core.version>1.2.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 
-		<json.schema.validator.version>2.2.10</json.schema.validator.version>
+		<json.schema.validator.version>2.2.14</json.schema.validator.version>
 	</properties>
      	<dependencyManagement>
 		<dependencies>
@@ -124,7 +124,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idvalidator-mispid/pom.xml
+++ b/kernel/kernel-idvalidator-mispid/pom.xml
@@ -58,7 +58,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idvalidator-prid/pom.xml
+++ b/kernel/kernel-idvalidator-prid/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idvalidator-rid/pom.xml
+++ b/kernel/kernel-idvalidator-rid/pom.xml
@@ -58,7 +58,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idvalidator-uin/pom.xml
+++ b/kernel/kernel-idvalidator-uin/pom.xml
@@ -58,7 +58,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-idvalidator-vid/pom.xml
+++ b/kernel/kernel-idvalidator-vid/pom.xml
@@ -61,7 +61,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-licensekeygenerator-misp/pom.xml
+++ b/kernel/kernel-licensekeygenerator-misp/pom.xml
@@ -87,7 +87,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-logger-logback/pom.xml
+++ b/kernel/kernel-logger-logback/pom.xml
@@ -91,7 +91,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-notification-service/pom.xml
+++ b/kernel/kernel-notification-service/pom.xml
@@ -140,7 +140,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-pdfgenerator-itext/pom.xml
+++ b/kernel/kernel-pdfgenerator-itext/pom.xml
@@ -114,7 +114,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-pinvalidator/pom.xml
+++ b/kernel/kernel-pinvalidator/pom.xml
@@ -74,7 +74,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-pridgenerator-service/pom.xml
+++ b/kernel/kernel-pridgenerator-service/pom.xml
@@ -194,7 +194,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-qrcodegenerator-zxing/pom.xml
+++ b/kernel/kernel-qrcodegenerator-zxing/pom.xml
@@ -62,7 +62,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-ridgenerator-service/pom.xml
+++ b/kernel/kernel-ridgenerator-service/pom.xml
@@ -128,7 +128,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-salt-generator/pom.xml
+++ b/kernel/kernel-salt-generator/pom.xml
@@ -146,7 +146,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-templatemanager-velocity/pom.xml
+++ b/kernel/kernel-templatemanager-velocity/pom.xml
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-transliteration-icu4j/pom.xml
+++ b/kernel/kernel-transliteration-icu4j/pom.xml
@@ -83,7 +83,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/kernel-websubclient-api/pom.xml
+++ b/kernel/kernel-websubclient-api/pom.xml
@@ -79,7 +79,7 @@
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
+				<version>1.6.14</version>
 				<extensions>true</extensions>
 				<executions>
 					<execution>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -240,7 +240,7 @@
                <plugin>
                   <groupId>org.sonatype.plugins</groupId>
                   <artifactId>nexus-staging-maven-plugin</artifactId>
-                  <version>1.6.7</version>
+                  <version>1.6.14</version>
                   <extensions>true</extensions>
                   <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                <plugin>
                   <groupId>org.sonatype.plugins</groupId>
                   <artifactId>nexus-staging-maven-plugin</artifactId>
-                  <version>1.6.7</version>
+                  <version>1.6.14</version>
                   <extensions>true</extensions>
                   <executions>
                     <execution>


### PR DESCRIPTION
spring active profile is set to composite.
To make it work, we need to add composite properties through env variables.
Adding type and uri are mandatory properties.
If we don't specify default_label which is known as branch, it will refer to main branch of repo. In our repositories we have main branch as master. Because of this providing default_label becomes mandatory for us.

Env variables to set for composite profile are as
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_URI=https://github.com/mosip/inji-config
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=git
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_DEFAULT_LABEL=develop

export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_URI=https://github.com/mosip/mosip-config
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_TYPE=git
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_DEFAULT_LABEL=develop

for native
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_URI=file-path-for-local-properties
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_TYPE=native
export SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_1_DEFAULT_LABEL=develop