### PR TITLE
[DSD-9252]Added SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_SIGNUP_HOST

### DIFF
--- a/helm/config-server/values.yaml
+++ b/helm/config-server/values.yaml
@@ -296,7 +296,14 @@ envVariables:
         name: global
         key: mosip-esignet-host
     enabled: true
-
+    
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_SIGNUP_HOST
+    valueFrom:
+      configMapKeyRef:
+        name: global
+        key: mosip-signup-host
+    enabled: true
+   
   - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_DB_DBUSER_PASSWORD
     valueFrom:
       secretKeyRef:

--- a/helm/config-server/values.yaml
+++ b/helm/config-server/values.yaml
@@ -296,14 +296,14 @@ envVariables:
         name: global
         key: mosip-esignet-host
     enabled: true
-    
+
   - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_SIGNUP_HOST
     valueFrom:
       configMapKeyRef:
         name: global
         key: mosip-signup-host
     enabled: true
-   
+
   - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_DB_DBUSER_PASSWORD
     valueFrom:
       secretKeyRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to add a new environment variable enabling override of the signup host via global configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->