### PR TITLE
MOSIP-43719: Refactor config-server to use spring composite repos ins…

### DIFF
--- a/deploy/config-server/install.sh
+++ b/deploy/config-server/install.sh
@@ -60,6 +60,7 @@ if [ $yn = "Y" ]
     --set volume.nfs.path="$NFS_PATH" \
     --set volume.nfs.server="$NFS_SERVER" \
     -f values.yaml \
+    --timeout 10m \
     --wait --version $CHART_VERSION
     echo "Installed Config-server".
   else

--- a/deploy/config-server/values.yaml
+++ b/deploy/config-server/values.yaml
@@ -4,7 +4,13 @@ spring_profiles:
   # Based on the user requiremnt the number of multiple sources from where configuration needs to be pulled can be updated below as mentioned.
     - type: git
       uri: "https://github.com/mosip/mosip-config"
-      version: release-1.3.x
+      version: "release-1.3.x"
+      ## Folders within the base repo where properties may be found.
+      searchFolders: ""
+      private: false
+      ## User name of user who has access to the private repo. Ignore for public repo
+      username: ""
+      token: ""
       spring_cloud_config_server_git_cloneOnStart: true
       spring_cloud_config_server_git_force_pull: true
       spring_cloud_config_server_git_refreshRate: 5
@@ -43,4 +49,29 @@ volume:
   nfs:
     path: ''  # Dir within the nfs server where config repo is cloned/maintained locally.
     server: ''  # Ip address of nfs server.
+
+## Extra environment variables to be passed to the config-server container
+## By default, these are enabled for development/testing. Set enabled: false in production if not needed.
+extraEnvVars:
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_KERNEL_UIN_MIN_UNUSED_THRESHOLD_OVERRIDE
+    value: "10000"
+    enabled: true
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_AUTH_SERVER_ADMIN_ALLOWED_AUDIENCE_IDREPO_OVERRIDE
+    value: "mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,opencrvs-partner,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client"
+    enabled: true
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_IDREPO_CREDENTIAL_REQUEST_ENABLE_CONVENTION_BASED_ID_IDREPO_OVERRIDE
+    value: "true"
+    enabled: true
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_AUTH_SERVER_ADMIN_ALLOWED_AUDIENCE_KERNEL_OVERRIDE
+    value: "mosip-toolkit-android-client,mosip-toolkit-client,mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,mobileid_newlogic,opencrvs-partner,mosip-deployment-client,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client"
+    enabled: true
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_KERNEL_VID_MIN_UNUSED_THRESHOLD_OVERRIDE
+    value: "10000"
+    enabled: true
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_PREREGISTRATION_CAPTCHA_ENABLE_OVERRIDE
+    value: "false"
+    enabled: true
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_ESIGNET_CAPTCHA_REQUIRED_ESIGNET_OVERRIDE
+    value: ""
+    enabled: true
     

--- a/helm/config-server/templates/configmap-env-vars.yaml
+++ b/helm/config-server/templates/configmap-env-vars.yaml
@@ -4,15 +4,14 @@ metadata:
   name: {{ printf "%s-env-vars" (include "config-server.fullname" .) }}
   namespace: {{ .Release.Namespace }}
 data:
-  SPRING_CLOUD_CONFIG_SERVER_GIT_SEARCHPATHS: {{ .Values.gitRepo.searchFolders  | quote }}
   {{- if .Values.spring_profiles.enabled }}
   {{- range $index, $repo := .Values.spring_profiles.spring_compositeRepos }}
   SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_{{ $index }}_URI: "{{ $repo.uri }}"
+  SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_{{ $index }}_SEARCHPATHS: {{ $repo.searchFolders | default "" | quote }}
+  {{- if $repo.username }}
+  SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_{{ $index }}_USERNAME: {{ $repo.username | quote }}
+  {{- end }}
   {{- end }}
   {{- else if .Values.localRepo.enabled }}
   SPRING_CLOUD_CONFIG_SERVER_GIT_URI: {{ .Values.volume.mountDir | quote }}
-  
-  {{- else }}
-  SPRING_CLOUD_CONFIG_SERVER_GIT_URI: {{ .Values.gitRepo.uri | quote }}
   {{- end }}
-  SPRING_CLOUD_CONFIG_SERVER_GIT_USERNAME: {{ .Values.gitRepo.username | quote  }}

--- a/helm/config-server/templates/configmap-share.yaml
+++ b/helm/config-server/templates/configmap-share.yaml
@@ -9,8 +9,22 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   active_profile_env : {{ .Values.activeProfileEnv }}
-  spring_config_label_env: {{ .Values.gitRepo.version }}
+  {{- if .Values.spring_profiles.enabled }}
+  {{- with (index .Values.spring_profiles.spring_compositeRepos 0) }}
+  spring_config_label_env: {{ .version }}
+  {{- end }}
+  {{- else }}
+  spring_config_label_env: "develop"
+  {{- end }}
   spring_config_url_env: {{ printf "http://%s.%s/config" (include "config-server.fullname" .) .Release.Namespace }}
-  cache_config_url_env: {{ printf "http://%s.%s/config/application/%s/%s/hazelcast_cache.xml" (include "config-server.fullname" .) .Release.Namespace .Values.activeProfileEnv .Values.gitRepo.version }}
-  hub_config_file_url_env: {{ printf "http://%s.%s/config/application/%s/%s/websub-service.toml" (include "config-server.fullname" .) .Release.Namespace .Values.activeProfileEnv .Values.gitRepo.version }}
-  consolidator_config_file_url_env: {{ printf "http://%s.%s/config/application/%s/%s/websub-consolidator.toml" (include "config-server.fullname" .) .Release.Namespace .Values.activeProfileEnv .Values.gitRepo.version }}
+  {{- if .Values.spring_profiles.enabled }}
+  {{- with (index .Values.spring_profiles.spring_compositeRepos 0) }}
+  cache_config_url_env: {{ printf "http://%s.%s/config/application/%s/%s/hazelcast_cache.xml" (include "config-server.fullname" $) $.Release.Namespace $.Values.activeProfileEnv .version }}
+  hub_config_file_url_env: {{ printf "http://%s.%s/config/application/%s/%s/websub-service.toml" (include "config-server.fullname" $) $.Release.Namespace $.Values.activeProfileEnv .version }}
+  consolidator_config_file_url_env: {{ printf "http://%s.%s/config/application/%s/%s/websub-consolidator.toml" (include "config-server.fullname" $) $.Release.Namespace $.Values.activeProfileEnv .version }}
+  {{- end }}
+  {{- else }}
+  cache_config_url_env: {{ printf "http://%s.%s/config/application/%s/develop/hazelcast_cache.xml" (include "config-server.fullname" .) .Release.Namespace .Values.activeProfileEnv }}
+  hub_config_file_url_env: {{ printf "http://%s.%s/config/application/%s/develop/websub-service.toml" (include "config-server.fullname" .) .Release.Namespace .Values.activeProfileEnv }}
+  consolidator_config_file_url_env: {{ printf "http://%s.%s/config/application/%s/develop/websub-consolidator.toml" (include "config-server.fullname" .) .Release.Namespace .Values.activeProfileEnv }}
+  {{- end }}

--- a/helm/config-server/templates/deployment.yaml
+++ b/helm/config-server/templates/deployment.yaml
@@ -69,12 +69,21 @@ spec:
             - name: spring_cloud_config_server_git_cloneOnStart
               value: {{ .Values.localRepo.spring_cloud_config_server_git_cloneOnStart | quote }}          
           {{- end }}
- 
-            - name: SPRING_CLOUD_CONFIG_SERVER_GIT_PASSWORD
+          {{- if .Values.spring_profiles.enabled }}
+          {{- range $index, $repo := .Values.spring_profiles.spring_compositeRepos }}
+          {{- if $repo.token }}
+            - name: SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_{{ $index }}_PASSWORD
               valueFrom:
                  secretKeyRef:
-                   name: {{ include "config-server.fullname" . }}
-                   key: github-token
+                   name: {{ include "config-server.fullname" $ }}
+                   key: github-token-{{ $index }}
+          {{- end }}
+          {{- if $repo.username }}
+            - name: SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_{{ $index }}_USERNAME
+              value: {{ $repo.username | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
             {{- range .Values.envVariables }}
             {{- if .enabled }}
             - name: {{ .name }}
@@ -91,9 +100,13 @@ spec:
             {{- end }}
             {{- end }}
 
-
             {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- range .Values.extraEnvVars }}
+            {{- if .enabled }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/helm/config-server/templates/secret.yaml
+++ b/helm/config-server/templates/secret.yaml
@@ -7,4 +7,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  github-token: {{ .Values.gitRepo.token | quote }}
+  {{- if .Values.spring_profiles.enabled }}
+  {{- range $index, $repo := .Values.spring_profiles.spring_compositeRepos }}
+  {{- if $repo.token }}
+  github-token-{{ $index }}: {{ $repo.token | quote }}
+  {{- else }}
+  github-token-{{ $index }}: ""
+  {{- end }}
+  {{- end }}
+  {{- else }}
+  github-token: ""
+  {{- end }}

--- a/helm/config-server/values.yaml
+++ b/helm/config-server/values.yaml
@@ -134,26 +134,21 @@ tolerations: []
 
 affinity: {}
 
-## Git repository from where config server will read the properties etc.  This repo could public or private
-## For private repos access token is required.
-## version: branch/tag of the repo to be used
-gitRepo:
-  uri: https://github.com/mosip/mosip-config
-  version: develop
-  ## Folders within the base repo where properties may be found.
-  searchFolders: ""
-  private: false
- ## User name of user who has access to the private repo. Ignore for public repo
-  username: ""
-  token: ""
+
 
 spring_profiles:
   enabled: true
   spring_compositeRepos:
   # Based on the user requiremnt the number of multiple sources from where configuration needs to be pulled can be updated below as mentioned.
     - type: git
-      uri: "< config-repo url >"
-      version: < branch-name >
+      uri: "https://github.com/mosip/mosip-config"
+      version: "develop"
+      ## Folders within the base repo where properties may be found.
+      searchFolders: ""
+      private: false
+      ## User name of user who has access to the private repo. Ignore for public repo
+      username: ""
+      token: ""
       spring_cloud_config_server_git_cloneOnStart: true
       spring_cloud_config_server_git_force_pull: true
       spring_cloud_config_server_git_refreshRate: 5
@@ -812,3 +807,28 @@ envVariables:
 ## The active profile env if you have another set of properties. Correspondingly, properties in Git repo will
 ## have names of type "*-default.properties"
 activeProfileEnv: default
+
+## Extra environment variables to be passed to the config-server container
+## By default, these are disabled in helm chart. Override in deploy values.yaml as needed.
+extraEnvVars:
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_KERNEL_UIN_MIN_UNUSED_THRESHOLD_OVERRIDE
+    value: "10000"
+    enabled: false
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_AUTH_SERVER_ADMIN_ALLOWED_AUDIENCE_IDREPO_OVERRIDE
+    value: "mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,opencrvs-partner,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client"
+    enabled: false
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_IDREPO_CREDENTIAL_REQUEST_ENABLE_CONVENTION_BASED_ID_IDREPO_OVERRIDE
+    value: "true"
+    enabled: false
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_AUTH_SERVER_ADMIN_ALLOWED_AUDIENCE_KERNEL_OVERRIDE
+    value: "mosip-toolkit-android-client,mosip-toolkit-client,mosip-regproc-client,mosip-prereg-client,mosip-admin-client,mosip-crereq-client,mosip-creser-client,mosip-datsha-client,mosip-ida-client,mosip-resident-client,mosip-reg-client,mpartner-default-print,mosip-idrepo-client,mpartner-default-auth,mosip-syncdata-client,mosip-masterdata-client,mosip-idrepo-client,mosip-pms-client,mosip-hotlist-client,mobileid_newlogic,opencrvs-partner,mosip-deployment-client,mpartner-default-digitalcard,mpartner-default-mobile,mosip-signup-client,mosip-testrig-client"
+    enabled: false
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_KERNEL_VID_MIN_UNUSED_THRESHOLD_OVERRIDE
+    value: "10000"
+    enabled: false
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_PREREGISTRATION_CAPTCHA_ENABLE_OVERRIDE
+    value: "false"
+    enabled: false
+  - name: SPRING_CLOUD_CONFIG_SERVER_OVERRIDES_MOSIP_ESIGNET_CAPTCHA_REQUIRED_ESIGNET_OVERRIDE
+    value: ""
+    enabled: false

--- a/helm/config-server/values.yaml
+++ b/helm/config-server/values.yaml
@@ -134,8 +134,6 @@ tolerations: []
 
 affinity: {}
 
-
-
 spring_profiles:
   enabled: true
   spring_compositeRepos:


### PR DESCRIPTION
…tead of gitRepo

- Removed gitRepo section from values.yaml
- Enhanced spring_compositeRepos with searchFolders, private, username, and token fields
- Updated all templates (configmap-env-vars, configmap-share, secret, deployment) to use composite repos
- Added extraEnvVars section with enabled flag for optional environment overrides
- Updated deploy/config-server/values.yaml with same changes
- Added --timeout 10m to install.sh for longer deployment wait time
- Supports both public and private Git repositories
- Maintains backward compatibility with localRepo configuration