### PR TITLE
MOSIP-44198: Fix the uin-generator pod restart issue

### DIFF
--- a/kernel/kernel-applicanttype-api/pom.xml
+++ b/kernel/kernel-applicanttype-api/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-applicanttype-api</artifactId>
 	<description>Mosip Applicant type API</description>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<properties>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
@@ -16,7 +16,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-core</artifactId>
-			<version>1.3.0</version>
+			<version>1.3.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mvel</groupId>

--- a/kernel/kernel-bom/pom.xml
+++ b/kernel/kernel-bom/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
     <groupId>io.mosip.kernel</groupId>
     <artifactId>kernel-bom</artifactId>
     <packaging>pom</packaging>

--- a/kernel/kernel-config-server/pom.xml
+++ b/kernel/kernel-config-server/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>io.mosip.kernel</groupId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<artifactId>kernel-config-server</artifactId>
 	<name>Kernel Config Server</name>
 		<url>https://github.com/mosip/commons</url>
@@ -34,7 +34,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-core/pom.xml
+++ b/kernel/kernel-core/pom.xml
@@ -5,7 +5,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -28,7 +28,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-dataaccess-hibernate/pom.xml
+++ b/kernel/kernel-dataaccess-hibernate/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-dataaccess-hibernate</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -23,7 +23,7 @@
 		<maven.javadoc.version>3.2.0</maven.javadoc.version>
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
 
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
 	<dependencyManagement>
@@ -31,7 +31,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-datamapper-orika/pom.xml
+++ b/kernel/kernel-datamapper-orika/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>io.mosip.kernel</groupId>
 
 	<artifactId>kernel-datamapper-orika</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-datamapper-orika</name>
 	<url>http://maven.apache.org</url>
 	<description>Mosip commons project </description>
@@ -18,7 +18,7 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.version>3.8.0</maven.compiler.version>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 
 		<datamapper.orika>1.5.2</datamapper.orika>

--- a/kernel/kernel-demographics-api/pom.xml
+++ b/kernel/kernel-demographics-api/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>io.mosip.kernel</groupId>
 
 	<artifactId>kernel-demographics-api</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-demographics-api</name>
 	<description>demographics api definitions</description>
 	<url>https://github.com/mosip/commons</url>
@@ -113,7 +113,7 @@
 		<micrometer.registry.prometheus.version>1.4.2</micrometer.registry.prometheus.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -121,7 +121,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-idgenerator-machineid/pom.xml
+++ b/kernel/kernel-idgenerator-machineid/pom.xml
@@ -5,16 +5,16 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-idgenerator-machineid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.applicant-type.version>1.3.0</kernel.applicant-type.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
-		<kernel.logger.version>1.3.0</kernel.logger.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.applicant-type.version>1.3.1-SNAPSHOT</kernel.applicant-type.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
+		<kernel.logger.version>1.3.1-SNAPSHOT</kernel.logger.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -22,7 +22,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-idgenerator-mispid/pom.xml
+++ b/kernel/kernel-idgenerator-mispid/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>io.mosip.kernel</groupId>
 
 	<artifactId>kernel-idgenerator-mispid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-idgenerator-mispid</name>
 	<description>Mosip commons project </description>
 	<url>https://github.com/mosip/commons</url>
@@ -16,9 +16,9 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-        	<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
-		<kernel.logger.version>1.3.0</kernel.logger.version>
+        	<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
+		<kernel.logger.version>1.3.1-SNAPSHOT</kernel.logger.version>
     		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -26,7 +26,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-idgenerator-partnerid/pom.xml
+++ b/kernel/kernel-idgenerator-partnerid/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-idgenerator-partnerid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-idgenerator-partnerid</name>
 	<description>Mosip commons project </description>
 	<url>http://maven.apache.org</url>
@@ -14,9 +14,9 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
-		<kernel.logger.version>1.3.0</kernel.logger.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
+		<kernel.logger.version>1.3.1-SNAPSHOT</kernel.logger.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -24,7 +24,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-idgenerator-prid/pom.xml
+++ b/kernel/kernel-idgenerator-prid/pom.xml
@@ -12,10 +12,10 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
-		<kernel.logger.version>1.3.0</kernel.logger.version>
-		<kernel.idvalidator-prid.version>1.3.0</kernel.idvalidator-prid.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
+		<kernel.logger.version>1.3.1-SNAPSHOT</kernel.logger.version>
+		<kernel.idvalidator-prid.version>1.3.1-SNAPSHOT</kernel.idvalidator-prid.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -23,14 +23,14 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<artifactId>kernel-idgenerator-prid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>

--- a/kernel/kernel-idgenerator-regcenterid/pom.xml
+++ b/kernel/kernel-idgenerator-regcenterid/pom.xml
@@ -10,11 +10,11 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
-		<kernel.logger.version>1.3.0</kernel.logger.version>
-		<kernel.idvalidator-prid.version>1.3.0</kernel.idvalidator-prid.version>
-		<kernel.crypto-jce.version>1.3.0</kernel.crypto-jce.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
+		<kernel.logger.version>1.3.1-SNAPSHOT</kernel.logger.version>
+		<kernel.idvalidator-prid.version>1.3.1-SNAPSHOT</kernel.idvalidator-prid.version>
+		<kernel.crypto-jce.version>1.3.1-SNAPSHOT</kernel.crypto-jce.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -22,14 +22,14 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<artifactId>kernel-idgenerator-regcenterid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>

--- a/kernel/kernel-idgenerator-rid/pom.xml
+++ b/kernel/kernel-idgenerator-rid/pom.xml
@@ -8,15 +8,15 @@
 	<groupId>io.mosip.kernel</groupId>
 
 	<artifactId>kernel-idgenerator-rid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
     <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
    		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -24,7 +24,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-idgenerator-service/pom.xml
+++ b/kernel/kernel-idgenerator-service/pom.xml
@@ -13,8 +13,8 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.idgenerator.vid.version>1.3.0</kernel.idgenerator.vid.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.idgenerator.vid.version>1.3.1-SNAPSHOT</kernel.idgenerator.vid.version>
 		<ceylon.complete.version>1.3.2</ceylon.complete.version>
 		<vertx.lang.ceylon.version>3.4.1</vertx.lang.ceylon.version>
 		<kernel.templatemanager.velocity.version>1.3.0</kernel.templatemanager.velocity.version>

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/config/HibernateDaoConfig.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/config/HibernateDaoConfig.java
@@ -64,15 +64,15 @@ public class HibernateDaoConfig implements EnvironmentAware {
 	@Autowired
 	private Environment env;
 
-	@Value("${mosip.kernel.vid.hikari_maximumPoolSize:10}")
+	@Value("${mosip.kernel.vid.hikari_maximumPoolSize:50}")
 	private int maximumPoolSize;
 	@Value("${hikari.validationTimeout:3000}")
 	private int validationTimeout;
-	@Value("${hikari.connectionTimeout:60000}")
+	@Value("${hikari.connectionTimeout:10000}")
 	private int connectionTimeout;
 	@Value("${hikari.idleTimeout:200000}")
 	private int idleTimeout;
-	@Value("${hikari.minimumIdle:0}")
+	@Value("${hikari.minimumIdle:5}")
 	private int minimumIdle;
 
 	/*

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/config/UinServiceRouter.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/config/UinServiceRouter.java
@@ -119,9 +119,9 @@ public class UinServiceRouter {
 		UinServiceHealthCheckerhandler healthCheckHandler = new UinServiceHealthCheckerhandler(vertx, null,
 				objectMapper, environment);
 		router.get(servletPath + UinGeneratorConstant.HEALTH_ENDPOINT).handler(healthCheckHandler);
-		healthCheckHandler.register("db", healthCheckHandler::databaseHealthChecker);
-		healthCheckHandler.register("diskspace", healthCheckHandler::dispSpaceHealthChecker);
-		healthCheckHandler.register("uingeneratorverticle",
+		healthCheckHandler.register("db", 3000, healthCheckHandler::databaseHealthChecker);
+		healthCheckHandler.register("diskspace", 3000, healthCheckHandler::dispSpaceHealthChecker);
+		healthCheckHandler.register("uingeneratorverticle", 3000,
 				future -> healthCheckHandler.verticleHealthHandler(future, vertx));
 	}
 

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/verticle/HttpServerVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/idgenerator/verticle/HttpServerVerticle.java
@@ -77,9 +77,9 @@ public class HttpServerVerticle extends AbstractVerticle {
 				new ObjectMapper(), environment);
 		healthCheckRouter.get(UinGeneratorConstant.HEALTH_ENDPOINT)
 				.handler(healthCheckHandler);
-		healthCheckHandler.register("db", healthCheckHandler::databaseHealthChecker);
-		healthCheckHandler.register("diskspace", healthCheckHandler::dispSpaceHealthChecker);
-		healthCheckHandler.register("idgenerator", f -> healthCheckHandler.verticleHealthHandler(f, vertx));
+		healthCheckHandler.register("db", 3000, healthCheckHandler::databaseHealthChecker);
+		healthCheckHandler.register("diskspace", 3000, healthCheckHandler::dispSpaceHealthChecker);
+		healthCheckHandler.register("idgenerator", 3000, f -> healthCheckHandler.verticleHealthHandler(f, vertx));
 
 		metricRouter.route("/metrics").handler(PrometheusScrapingHandler.create());
 

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/uingenerator/verticle/UinGeneratorVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/uingenerator/verticle/UinGeneratorVerticle.java
@@ -50,23 +50,23 @@ public class UinGeneratorVerticle extends AbstractVerticle {
 	@Override
 	public void start() {
 		vertx.eventBus().consumer(UinGeneratorConstant.UIN_GENERATOR_ADDRESS, receivedMessage -> {
-			if (receivedMessage.body().equals(UinGeneratorConstant.GENERATE_UIN) && uinProcesser.shouldGenerateUins()
-					&& !locked.get()) {
+			if (receivedMessage.body().equals(UinGeneratorConstant.GENERATE_UIN) && !locked.get()) {
 				vertx.executeBlocking(future -> {
 					locked.set(true);
-					uinProcesser.generateUins();
+					if (uinProcesser.shouldGenerateUins()) {
+						uinProcesser.generateUins();
+					}
 					future.complete();
 				}, result -> {
+					locked.set(false);
 					if (result.succeeded()) {
-						locked.set(false);
-						 LOGGER.info("Generated and persisted uins lock set to false");
+						LOGGER.info("Generated and persisted uins lock set to false");
 					} else {
-
-						 LOGGER.error("Uin Genaration failed", result.cause());
+						LOGGER.error("Uin Genaration failed", result.cause());
 					}
 				});
-			}else {
-				 LOGGER.info("Generated and persisted uins lock is true.");
+			} else {
+				LOGGER.info("Generated and persisted uins lock is true.");
 			}
 			receivedMessage.reply(UINHealthConstants.ACTIVE);
 		});

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/uingenerator/verticle/UinTransferVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/uingenerator/verticle/UinTransferVerticle.java
@@ -55,7 +55,14 @@ public class UinTransferVerticle extends AbstractVerticle {
 		MessageConsumer<JsonObject> consumer = eventBus.consumer(UinSchedulerConstants.NAME_VALUE);
 
 		// handle chime event
-		consumer.handler(message -> uinService.transferUin());
+		consumer.handler(message -> vertx.executeBlocking(future -> {
+			uinService.transferUin();
+			future.complete();
+		}, false, result -> {
+			if (result.failed()) {
+				LOGGER.error("UIN transfer failed", result.cause());
+			}
+		}));
 
 		JsonObject timer = new JsonObject()
 				.put(UinSchedulerConstants.TYPE, environment.getProperty(UinSchedulerConstants.TYPE_VALUE))

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidExpiryVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidExpiryVerticle.java
@@ -55,7 +55,14 @@ public class VidExpiryVerticle extends AbstractVerticle {
 		MessageConsumer<JsonObject> consumer = eventBus.consumer(VidSchedulerConstants.NAME_VALUE);
 
 		// handle chime event
-		consumer.handler(message -> vidService.expireAndRelease());
+		consumer.handler(message -> vertx.executeBlocking(future -> {
+			vidService.expireAndRelease();
+			future.complete();
+		}, false, result -> {
+			if (result.failed()) {
+				LOGGER.error("VID expiry and release failed", result.cause());
+			}
+		}));
 
 		JsonObject timer = new JsonObject()
 				.put(VidSchedulerConstants.TYPE, environment.getProperty(VidSchedulerConstants.TYPE_VALUE))

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidIsolatorVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidIsolatorVerticle.java
@@ -55,7 +55,14 @@ public class VidIsolatorVerticle extends AbstractVerticle {
 		MessageConsumer<JsonObject> consumer = eventBus.consumer(VidIsolatorSchedulerConstants.NAME_VALUE);
 
 		// handle chime event
-		consumer.handler(message -> vidService.isolateAssignedVids());
+		consumer.handler(message -> vertx.executeBlocking(future -> {
+			vidService.isolateAssignedVids();
+			future.complete();
+		}, false, result -> {
+			if (result.failed()) {
+				LOGGER.error("VID isolation failed", result.cause());
+			}
+		}));
 
 		JsonObject timer = new JsonObject()
 			.put(VidIsolatorSchedulerConstants.TYPE, environment.getProperty(VidIsolatorSchedulerConstants.TYPE_VALUE))

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidPoolCheckerVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidPoolCheckerVerticle.java
@@ -48,49 +48,65 @@ public class VidPoolCheckerVerticle extends AbstractVerticle {
 		DeliveryOptions deliveryOptions = new DeliveryOptions();
 		deliveryOptions.setSendTimeout(environment.getProperty("mosip.kernel.vid.pool-population-timeout", Long.class));
 		checkPoolConsumer.handler(handler -> {
-			long noOfFreeVids = vidService.fetchVidCount(VidLifecycleStatus.AVAILABLE);
-			LOGGER.info("no of vid free present are {}", noOfFreeVids);
-			if (noOfFreeVids < threshold && !locked.get()) {
-				locked.set(true);
-				eventBus.send(EventType.GENERATEPOOL, noOfFreeVids, deliveryOptions, replyHandler -> {
-					if (replyHandler.succeeded()) {
-						locked.set(false);
-						LOGGER.info("population of pool done");
-					} else if (replyHandler.failed()) {
-						locked.set(false);
-						LOGGER.error("population failed with cause ", replyHandler.cause());
-					}
-				});
-			} else {
-				LOGGER.info("event type is send {} eventBus{}", handler.isSend(), eventBus);
-				LOGGER.info("locked generation");
-			}
+			vertx.executeBlocking(future -> {
+				future.complete(vidService.fetchVidCount(VidLifecycleStatus.AVAILABLE));
+			}, false, result -> {
+				if (result.failed()) {
+					LOGGER.error("failed to fetch vid count ", result.cause());
+					return;
+				}
+				long noOfFreeVids = (Long) result.result();
+				LOGGER.info("no of vid free present are {}", noOfFreeVids);
+				if (noOfFreeVids < threshold && !locked.get()) {
+					locked.set(true);
+					eventBus.send(EventType.GENERATEPOOL, noOfFreeVids, deliveryOptions, replyHandler -> {
+						if (replyHandler.succeeded()) {
+							locked.set(false);
+							LOGGER.info("population of pool done");
+						} else if (replyHandler.failed()) {
+							locked.set(false);
+							LOGGER.error("population failed with cause ", replyHandler.cause());
+						}
+					});
+				} else {
+					LOGGER.info("event type is send {} eventBus{}", handler.isSend(), eventBus);
+					LOGGER.info("locked generation");
+				}
+			});
 		});
 
 		MessageConsumer<String> initPoolConsumer = eventBus.consumer(EventType.INITPOOL);
 		initPoolConsumer.handler(initPoolHandler -> {
 			long start = System.currentTimeMillis();
-			long noOfFreeVids = vidService.fetchVidCount(VidLifecycleStatus.AVAILABLE);
-			LOGGER.info("no of vid free present are {}", noOfFreeVids);
-			LOGGER.info("value of threshold is {} and lock is {}", threshold, locked.get());
-			boolean isEligibleForPool = noOfFreeVids < threshold && !locked.get();
-			LOGGER.info("is eligible for pool {}", isEligibleForPool);
-			if (isEligibleForPool) {
-				locked.set(true);
-				eventBus.send(EventType.GENERATEPOOL, noOfFreeVids, deliveryOptions, replyHandler -> {
-					if (replyHandler.succeeded()) {
-						locked.set(false);
-						deployHttpVerticle(start);
-						LOGGER.info("population of init pool done");
-					} else if (replyHandler.failed()) {
-						locked.set(false);
-						LOGGER.error("population failed with cause ", replyHandler.cause());
-						initPoolHandler.fail(100, replyHandler.cause().getMessage());
-					}
-				});
-			} else {
-				deployHttpVerticle(start);
-			}
+			vertx.executeBlocking(future -> {
+				future.complete(vidService.fetchVidCount(VidLifecycleStatus.AVAILABLE));
+			}, false, result -> {
+				if (result.failed()) {
+					LOGGER.error("failed to fetch vid count ", result.cause());
+					return;
+				}
+				long noOfFreeVids = (Long) result.result();
+				LOGGER.info("no of vid free present are {}", noOfFreeVids);
+				LOGGER.info("value of threshold is {} and lock is {}", threshold, locked.get());
+				boolean isEligibleForPool = noOfFreeVids < threshold && !locked.get();
+				LOGGER.info("is eligible for pool {}", isEligibleForPool);
+				if (isEligibleForPool) {
+					locked.set(true);
+					eventBus.send(EventType.GENERATEPOOL, noOfFreeVids, deliveryOptions, replyHandler -> {
+						if (replyHandler.succeeded()) {
+							locked.set(false);
+							deployHttpVerticle(start);
+							LOGGER.info("population of init pool done");
+						} else if (replyHandler.failed()) {
+							locked.set(false);
+							LOGGER.error("population failed with cause ", replyHandler.cause());
+							initPoolHandler.fail(100, replyHandler.cause().getMessage());
+						}
+					});
+				} else {
+					deployHttpVerticle(start);
+				}
+			});
 		});
 	}
 

--- a/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidPopulatorVerticle.java
+++ b/kernel/kernel-idgenerator-service/src/main/java/io/mosip/kernel/vidgenerator/verticle/VidPopulatorVerticle.java
@@ -45,21 +45,29 @@ public class VidPopulatorVerticle extends AbstractVerticle {
 			long noOfFreeVids = Long.parseLong(handler.body().toString());
 			long noOfVidsToGenerate = vidToGenerate - noOfFreeVids;
 			LOGGER.info("Persisting {} vids in pool", noOfVidsToGenerate);
-			long count = 0;
-			while (count < vidToGenerate) {
-				String vid = vidGenerator.generateId();
-				VidEntity entity = new VidEntity();
-				entity.setVid(vid);
-				entity.setStatus(VidLifecycleStatus.AVAILABLE);
-				metaDataUtil.setCreateMetaData(entity);
-				boolean isPersisted = vidWriter.persistVids(entity);
-				if (isPersisted) {
-					count++;
+			vertx.executeBlocking(future -> {
+				long count = 0;
+				while (count < vidToGenerate) {
+					String vid = vidGenerator.generateId();
+					VidEntity entity = new VidEntity();
+					entity.setVid(vid);
+					entity.setStatus(VidLifecycleStatus.AVAILABLE);
+					metaDataUtil.setCreateMetaData(entity);
+					boolean isPersisted = vidWriter.persistVids(entity);
+					if (isPersisted) {
+						count++;
+					}
 				}
-			}
-			handler.reply("pool population successfull");
-
-			LOGGER.info("No of vids persisted are {}", count);
+				LOGGER.info("No of vids persisted are {}", count);
+				future.complete("pool population successfull");
+			}, false, result -> {
+				if (result.succeeded()) {
+					handler.reply(result.result());
+				} else {
+					LOGGER.error("VID pool population failed", result.cause());
+					handler.fail(500, result.cause().getMessage());
+				}
+			});
 		});
 	}
 }

--- a/kernel/kernel-idgenerator-service/src/main/resources/application-local.properties
+++ b/kernel/kernel-idgenerator-service/src/main/resources/application-local.properties
@@ -184,6 +184,9 @@ mosip.kernel.keymanager-service-publickey-url=https://dev.mosip.io/v1/keymanager
 
 mosip.kernel.uin.get_executor_pool=400
 mosip.kernel.uin.hikari_maximumPoolSize=400
+mosip.kernel.vid.hikari_maximumPoolSize=50
+hikari.connectionTimeout=5000
+hikari.minimumIdle=5
 auth.jwt.secret=authjwtsecret
 auth.jwt.base=Mosip-Token
 

--- a/kernel/kernel-idgenerator-tokenid/pom.xml
+++ b/kernel/kernel-idgenerator-tokenid/pom.xml
@@ -6,13 +6,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-idgenerator-tokenid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>
@@ -20,7 +20,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-idgenerator-vid/pom.xml
+++ b/kernel/kernel-idgenerator-vid/pom.xml
@@ -4,14 +4,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-idgenerator-vid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<kernel.idvalidator-vid.version>1.3.0</kernel.idvalidator-vid.version>
     	<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>

--- a/kernel/kernel-idobjectvalidator/pom.xml
+++ b/kernel/kernel-idobjectvalidator/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>kernel-idobjectvalidator</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 <groupId>io.mosip.kernel</groupId>
 <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -11,7 +11,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 
 		<json.schema.validator.version>2.2.14</json.schema.validator.version>
@@ -21,7 +21,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-idvalidator-mispid/pom.xml
+++ b/kernel/kernel-idvalidator-mispid/pom.xml
@@ -4,14 +4,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-idvalidator-mispid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
 	<dependencies>

--- a/kernel/kernel-idvalidator-prid/pom.xml
+++ b/kernel/kernel-idvalidator-prid/pom.xml
@@ -11,11 +11,11 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
 	<artifactId>kernel-idvalidator-prid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-idvalidator-prid</name>
 	<dependencies>
 		<dependency>

--- a/kernel/kernel-idvalidator-rid/pom.xml
+++ b/kernel/kernel-idvalidator-rid/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.mosip.kernel</groupId>
   <artifactId>kernel-idvalidator-rid</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>kernel-idvalidator-rid</name>
   <description>kernel-idvalidator-rid</description>
   <properties>		
@@ -11,7 +11,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
 	<dependencies>

--- a/kernel/kernel-idvalidator-uin/pom.xml
+++ b/kernel/kernel-idvalidator-uin/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.mosip.kernel</groupId>
   <artifactId>kernel-idvalidator-uin</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>kernel-idvalidator-uin</name>
   <description>kernel-idvalidator-uin</description>
   <properties>		
@@ -11,7 +11,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
 	<dependencies>

--- a/kernel/kernel-idvalidator-vid/pom.xml
+++ b/kernel/kernel-idvalidator-vid/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-idvalidator-vid</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-idvalidator-vid</name>
 	<description>kernel-idvalidator-vid</description>
 	<properties>
@@ -13,7 +13,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
     	<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
 	<dependencies>

--- a/kernel/kernel-licensekeygenerator-misp/pom.xml
+++ b/kernel/kernel-licensekeygenerator-misp/pom.xml
@@ -6,14 +6,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-licensekeygenerator-misp</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 <properties>		
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
     	<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
 	<dependencyManagement>
@@ -21,7 +21,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-logger-logback/pom.xml
+++ b/kernel/kernel-logger-logback/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-logger-logback</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 <properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -21,7 +21,7 @@
 		<maven.javadoc.version>3.2.0</maven.javadoc.version>
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
 
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 		
 	</properties>
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-notification-service/pom.xml
+++ b/kernel/kernel-notification-service/pom.xml
@@ -8,7 +8,7 @@
 	<name>kernel-notification-service</name>
 	<description>Mosip commons project </description>
 	<url>https://github.com/mosip/commons</url>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<groupId>io.mosip.kernel</groupId>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -18,8 +18,8 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.version>3.8.0</maven.compiler.version>
 
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.applicant-type.version>1.3.0</kernel.applicant-type.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.applicant-type.version>1.3.1-SNAPSHOT</kernel.applicant-type.version>
 		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
 		<kernel.logger.version>1.3.0</kernel.logger.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>

--- a/kernel/kernel-pdfgenerator/pom.xml
+++ b/kernel/kernel-pdfgenerator/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-pdfgenerator</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-pdfgenerator</name>
 	<description>generate pdf for given  template</description>
 	<properties>
@@ -13,7 +13,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 		<bouncycastle.version>1.66</bouncycastle.version>
 	</properties>
@@ -22,7 +22,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-pinvalidator/pom.xml
+++ b/kernel/kernel-pinvalidator/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-pinvalidator</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<url>http://maven.apache.org</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -12,7 +12,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 	</properties>
      	<dependencyManagement>

--- a/kernel/kernel-pridgenerator-service/pom.xml
+++ b/kernel/kernel-pridgenerator-service/pom.xml
@@ -10,8 +10,8 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.templatemanager-velocity.version>1.3.0</kernel.templatemanager-velocity.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.templatemanager-velocity.version>1.3.1-SNAPSHOT</kernel.templatemanager-velocity.version>
 		<kernel.logger.version>1.3.0</kernel.logger.version>
 		<kernel.prid-generator.version>1.3.0</kernel.prid-generator.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
@@ -19,7 +19,7 @@
 		<sonar.coverage.exclusions>**/constant/**,**/config/**,**/httpfilter/**,**/cache/**,**/entity/**,**/model/**,**/exception/**,**/repository/**,**/verticle/**,**/spi/**,"**/proxy/**","**/entities/**","**/filter/**","**/util/**","**/verifier/**","**/KernelPridgeneratorServiceApplication.java"</sonar.coverage.exclusions>
 	</properties>
 	<artifactId>kernel-pridgenerator-service</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
      	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/kernel/kernel-qrcodegenerator-zxing/pom.xml
+++ b/kernel/kernel-qrcodegenerator-zxing/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>io.mosip.kernel</groupId>
 
 	<artifactId>kernel-qrcodegenerator-zxing</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>kernel-qrcodegenerator-zxing</name>
@@ -16,7 +16,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 
 		<google.zxing.version>3.4.1</google.zxing.version>

--- a/kernel/kernel-ridgenerator-service/pom.xml
+++ b/kernel/kernel-ridgenerator-service/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-ridgenerator-service</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel-ridgenerator-service</name>
 	<description>Mosip commons project </description>
 	<url>https://github.com/mosip/commons</url>
@@ -17,9 +17,9 @@
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 		<maven.compiler.version>3.8.0</maven.compiler.version>
-		<kernel.core.version>1.3.0</kernel.core.version>
-		<kernel.dataaccess-hibernate.version>1.3.0</kernel.dataaccess-hibernate.version>
-		<kernel.logger.version>1.3.0</kernel.logger.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
+		<kernel.dataaccess-hibernate.version>1.3.1-SNAPSHOT</kernel.dataaccess-hibernate.version>
+		<kernel.logger.version>1.3.1-SNAPSHOT</kernel.logger.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 		<springdoc.version>1.5.10</springdoc.version>
 		<spring-boot-maven-plugin.version>3.2.3</spring-boot-maven-plugin.version>
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/kernel/kernel-salt-generator/pom.xml
+++ b/kernel/kernel-salt-generator/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-salt-generator</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>Kernel Salt Generator</name>
 	<description>Batch Job Application to for one-time populating of salt values for MOSIP related application salt tables.</description>
 	<url>https://github.com/mosip/commons</url>
@@ -24,8 +24,8 @@
 		<maven.javadoc.version>3.2.0</maven.javadoc.version>
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
 		<spring-boot-maven-plugin.version>3.2.3</spring-boot-maven-plugin.version>
-		<kernel-core.version>1.3.0</kernel-core.version>
-		<kernel-logger-logback.version>1.3.0</kernel-logger-logback.version>
+		<kernel-core.version>1.3.1-SNAPSHOT</kernel-core.version>
+		<kernel-logger-logback.version>1.3.1-SNAPSHOT</kernel-logger-logback.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 		<com.fasterxml.jackson.core.version>2.12.0</com.fasterxml.jackson.core.version>
 	</properties>
@@ -34,7 +34,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-templatemanager-velocity/pom.xml
+++ b/kernel/kernel-templatemanager-velocity/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-templatemanager-velocity</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<description>Mosip Template Manager Using Velocity Template Engine</description>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -12,7 +12,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 
 		<velocity.version>1.7</velocity.version>
@@ -23,7 +23,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-transliteration-icu4j/pom.xml
+++ b/kernel/kernel-transliteration-icu4j/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-transliteration-icu4j</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<name>kernel transliteration icu4j</name>
 	<url>https://github.com/mosip/commons</url>	
 	<description>kernel-transliteration-icu4j</description>
@@ -18,7 +18,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 		<icu4j.version>73.2</icu4j.version>
 	</properties>
@@ -27,7 +27,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.3.0</version>
+				<version>1.3.1-SNAPSHOT</version>
 				<type>pom</type>
 			    <scope>import</scope>
 			</dependency>

--- a/kernel/kernel-websubclient-api/pom.xml
+++ b/kernel/kernel-websubclient-api/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-websubclient-api</artifactId>
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>kernel-websubclient-api</name>
 	<description>Mosip commons project </description>
@@ -15,7 +15,7 @@
 		<!-- maven -->
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
-		<kernel.core.version>1.3.0</kernel.core.version>
+		<kernel.core.version>1.3.1-SNAPSHOT</kernel.core.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
 		<owasp.encoder.version>1.2.3</owasp.encoder.version>
 	</properties>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<version>1.3.0</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<groupId>io.mosip.kernel</groupId>
 	<artifactId>kernel-parent</artifactId>
 	<packaging>pom</packaging>


### PR DESCRIPTION

  1. VidPopulatorVerticle — VID generation while-loop blocking event loop

  The GENERATEPOOL consumer ran the entire generation loop (which calls vidGenerator.generateId() + a DB write per VID) directly on the event loop thread. Since VidPoolCheckerVerticle sends CHECKPOOL on every
  VID fetch request, pool replenishment was repeatedly blocking the event loop. Wrapped the loop in executeBlocking. Also added proper error handling — previously on failure, no reply was sent, leaving
  VidPoolCheckerVerticle waiting until the event bus delivery timeout (1000s by default).

  2. UinGeneratorVerticle — Two bugs

  Bug 1 (blocking): uinProcesser.shouldGenerateUins() calls uinRepository.countByStatus() (blocking DB query) on the event loop, evaluated on every single health ping and every UIN request. Moved inside
  executeBlocking.

  Bug 2 (permanent lock deadlock): The original else error handler never called locked.set(false). If generateUins() threw any exception, locked would stay true permanently — no UINs would ever generate again
  until pod restart, silently. Fixed by moving locked.set(false) to run unconditionally in the result handler.

  3. VidExpiryVerticle, VidIsolatorVerticle, UinTransferVerticle — Scheduler callbacks blocking event loop

  All three cron-triggered handlers called heavy transactional DB operations (expireAndRelease, isolateAssignedVids, transferUin) directly on the event loop thread. While these run less frequently than request
  handlers, under high load they compound the event loop starvation. All three wrapped in executeBlocking.