### PR TITLE
[BUG] Correct Error Code for Invalid Recipient Email Validation

### DIFF
--- a/kernel/kernel-notification-service/src/main/java/io/mosip/kernel/emailnotification/util/EmailNotificationUtils.java
+++ b/kernel/kernel-notification-service/src/main/java/io/mosip/kernel/emailnotification/util/EmailNotificationUtils.java
@@ -115,8 +115,8 @@ public class EmailNotificationUtils {
                     validateEmailAddress(to);
                 }
                 catch(AddressException ex){
-                    validationErrorsList.add(new ServiceError(MailNotifierArgumentErrorConstants.SENDER_ADDRESS_NOT_FOUND.getErrorCode(),
-                            MailNotifierArgumentErrorConstants.SENDER_ADDRESS_NOT_FOUND.getErrorMessage()));
+                    validationErrorsList.add(new ServiceError(MailNotifierArgumentErrorConstants.RECEIVER_ADDRESS_NOT_FOUND.getErrorCode(),
+                            MailNotifierArgumentErrorConstants.RECEIVER_ADDRESS_NOT_FOUND.getErrorMessage()));
                 }
             });
         }


### PR DESCRIPTION
### Summary
This PR fixes a bug in EmailNotificationUtils.java where an invalid recipient email address (mailTo) triggered a sender-related error code (KER-NOE-007) instead of the appropriate receiver-related error code (KER-NOE-001).

### Problem
In the tos validation loop, the catch block was hardcoded to return SENDER_ADDRESS_NOT_FOUND. This caused API consumers to receive misleading feedback ("From must be valid") when the actual issue was an invalid "To" address.

### Changes
**File:** EmailNotificationUtils.java

**Update:** Replaced SENDER_ADDRESS_NOT_FOUND with RECEIVER_ADDRESS_NOT_FOUND within the tos.forEach validation block.

### Impact
Accuracy: API error responses now correctly identify the recipient as the source of the validation failure.
UX: Developers and consumers will no longer be misled by "Sender" errors when troubleshooting recipient list issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error reporting for invalid recipient email addresses to display accurate error codes instead of misleading sender-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->