### PR TITLE
Remove Unused javax.inject.Qualifier Import

### DIFF
--- a/kernel/kernel-notification-service/src/main/java/io/mosip/kernel/emailnotification/util/EmailNotificationUtils.java
+++ b/kernel/kernel-notification-service/src/main/java/io/mosip/kernel/emailnotification/util/EmailNotificationUtils.java
@@ -24,7 +24,6 @@ import io.mosip.kernel.emailnotification.constant.MailNotifierConstants;
 import io.mosip.kernel.emailnotification.exception.InvalidArgumentsException;
 import io.mosip.kernel.emailnotification.exception.NotificationException;
 
-import javax.inject.Qualifier;
 
 /**
  * This class provides with the utility methods for email-notifier service.


### PR DESCRIPTION
### Summary
This PR removes a redundant and deprecated import in EmailNotificationUtils.java to clean up the codebase and complete the transition away from the javax.* namespace.

### Problem
Line 27 of EmailNotificationUtils.java imports javax.inject.Qualifier, which is:

- Unused: No members of the class utilize this annotation.
- Legacy: It belongs to the old Java EE namespace, whereas the project has migrated to Jakarta EE.

### Changes

- File: EmailNotificationUtils.java
- Action: Deleted the import javax.inject.Qualifier; statement.