### PR TITLE
Optimize ObjectMapper Configuration in Exception Handlers

### DIFF
--- a/kernel/kernel-notification-service/src/main/java/io/mosip/kernel/emailnotification/exception/EmailNotificationApiExceptionHandler.java
+++ b/kernel/kernel-notification-service/src/main/java/io/mosip/kernel/emailnotification/exception/EmailNotificationApiExceptionHandler.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import jakarta.annotation.PostConstruct;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,7 +45,12 @@ public class EmailNotificationApiExceptionHandler {
 	 */
 	@Autowired
 	private ObjectMapper objectMapper;
-	
+
+	@PostConstruct
+	private void init() {
+		objectMapper.registerModule(new JavaTimeModule());
+	}
+
 	private static final String WHITESPACE = " ";
 
 	/**
@@ -136,7 +143,6 @@ public class EmailNotificationApiExceptionHandler {
 		if (EmptyCheckUtils.isNullEmpty(requestBody)) {
 			return responseWrapper;
 		}
-		objectMapper.registerModule(new JavaTimeModule());
 		JsonNode reqNode = objectMapper.readTree(requestBody);
 		responseWrapper.setId(reqNode.path("id").asText());
 		responseWrapper.setVersion(reqNode.path("version").asText());

--- a/kernel/kernel-ridgenerator-service/src/main/java/io/mosip/kernel/ridgenerator/exception/ApiExceptionalHandler.java
+++ b/kernel/kernel-ridgenerator-service/src/main/java/io/mosip/kernel/ridgenerator/exception/ApiExceptionalHandler.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import jakarta.annotation.PostConstruct;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +38,11 @@ public class ApiExceptionalHandler {
 	 */
 	@Autowired
 	private ObjectMapper objectMapper;
+
+	@PostConstruct
+	private void init() {
+		objectMapper.registerModule(new JavaTimeModule());
+	}
 
 	public static final String WHITESPACE = " ";
 
@@ -121,7 +128,6 @@ public class ApiExceptionalHandler {
 		if (EmptyCheckUtils.isNullEmpty(requestBody)) {
 			return responseWrapper;
 		}
-		objectMapper.registerModule(new JavaTimeModule());
 		JsonNode reqNode = objectMapper.readTree(requestBody);
 		responseWrapper.setId(reqNode.path("id").asText());
 		responseWrapper.setVersion(reqNode.path("version").asText());


### PR DESCRIPTION
### Summary
This PR fixes a performance and thread-safety issue where JavaTimeModule was being redundantly registered on a shared ObjectMapper instance during every error response generation.

### Problem
In both `EmailNotificationApiExceptionHandler` and `ApiExceptionalHandler`, the `setErrors()` method was calling `objectMapper.registerModule(new JavaTimeModule())`. Since the ObjectMapper is an `@Autowired` singleton:

- Redundancy: The module was re-registered on every single API error, wasting CPU cycles.
- Thread Safety: Modifying the state of a shared singleton during request processing is not thread-safe and can lead to inconsistent behavior.

### Changes

- Files: EmailNotificationApiExceptionHandler.java, ApiExceptionalHandler.java
- Action: Removed the registration logic from the request-scoped setErrors() method.
- Action: Introduced a `@PostConstruct` method to register the JavaTimeModule exactly once when the bean is initialized.

### Impact

- Performance: Reduces overhead during exception handling by eliminating redundant configuration logic.
- Stability: Ensures the shared ObjectMapper is configured in a thread-safe manner during application startup rather than at runtime.