### PR TITLE
Add use-pr-linker workflow to auto-link PRs to issues

### DIFF
--- a/.github/workflows/use-pr-linker.yml
+++ b/.github/workflows/use-pr-linker.yml
@@ -1,0 +1,16 @@
+name: Auto link PR to Issues
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, closed, reopened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  call-linker:
+    uses: mosip/kattu/.github/workflows/link-pr-to-issue.yml@develop
+    secrets:
+      ACTION_PAT: ${{ secrets.ACTION_PAT }}

--- a/.github/workflows/use-pr-linker.yml
+++ b/.github/workflows/use-pr-linker.yml
@@ -1,8 +1,13 @@
 name: Auto link PR to Issues
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, closed, reopened]
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - closed
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `use-pr-linker.yml` calling `mosip/kattu` link-pr-to-issue.yml@develop. Requires ACTION_PAT secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to link pull requests to related issues during the PR lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->