### PR TITLE
[MOSIP-44855] fix: move javaOpts out of resources block in config-ser…

### DIFF
--- a/helm/config-server/templates/deployment.yaml
+++ b/helm/config-server/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           env:
+            - name: JDK_JAVA_OPTIONS
+              value: {{ .Values.additionalResources.javaOpts }}
           {{- if .Values.spring_profiles.enabled }}
             {{- range $index, $repo := .Values.spring_profiles.spring_compositeRepos }}
             - name: SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_{{ $index }}_URI

--- a/helm/config-server/values.yaml
+++ b/helm/config-server/values.yaml
@@ -106,6 +106,9 @@ resources:
   requests:
     cpu: 150m
     memory: 1500Mi
+additionalResources:
+  ## Specify any JAVA_OPTS string here. These typically will be specified in conjunction with above resources
+  ## Example: javaOpts: "-Xms500M -Xmx500M"
   javaOpts: >-
     -XX:+UseZGC -XX:+ZGenerational -XX:+ZUncommit -XX:+ZProactive
     -XX:ZUncommitDelay=60 -XX:SoftMaxHeapSize=1500m -Xms1200m -Xmx2000m


### PR DESCRIPTION
…ver helm chart

javaOpts was nested under resources: in values.yaml, causing helm install to fail with 'field not declared in schema' because Kubernetes only allows limits/requests/claims under container resources.

Moved javaOpts to a new additionalResources: top-level key (consistent with idgenerator/ridgenerator/pridgenerator charts) and added a JDK_JAVA_OPTIONS env var in deployment.yaml to render it correctly.