### PR TITLE
Updated central-publishing-maven-plugin version from 0.7.0 to 0.11.0 to fix Nexus publish failure #403

### DIFF
--- a/kernel/kernel-applicanttype-api/pom.xml
+++ b/kernel/kernel-applicanttype-api/pom.xml
@@ -54,7 +54,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-bom/pom.xml
+++ b/kernel/kernel-bom/pom.xml
@@ -378,7 +378,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-config-server/pom.xml
+++ b/kernel/kernel-config-server/pom.xml
@@ -103,7 +103,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-core/pom.xml
+++ b/kernel/kernel-core/pom.xml
@@ -272,7 +272,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-dataaccess-hibernate/pom.xml
+++ b/kernel/kernel-dataaccess-hibernate/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-datamapper-orika/pom.xml
+++ b/kernel/kernel-datamapper-orika/pom.xml
@@ -56,7 +56,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-demographics-api/pom.xml
+++ b/kernel/kernel-demographics-api/pom.xml
@@ -154,7 +154,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-machineid/pom.xml
+++ b/kernel/kernel-idgenerator-machineid/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-mispid/pom.xml
+++ b/kernel/kernel-idgenerator-mispid/pom.xml
@@ -76,7 +76,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-partnerid/pom.xml
+++ b/kernel/kernel-idgenerator-partnerid/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-prid/pom.xml
+++ b/kernel/kernel-idgenerator-prid/pom.xml
@@ -80,7 +80,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-regcenterid/pom.xml
+++ b/kernel/kernel-idgenerator-regcenterid/pom.xml
@@ -74,7 +74,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-rid/pom.xml
+++ b/kernel/kernel-idgenerator-rid/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-service/pom.xml
+++ b/kernel/kernel-idgenerator-service/pom.xml
@@ -204,7 +204,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-tokenid/pom.xml
+++ b/kernel/kernel-idgenerator-tokenid/pom.xml
@@ -85,7 +85,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idgenerator-vid/pom.xml
+++ b/kernel/kernel-idgenerator-vid/pom.xml
@@ -50,7 +50,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idobjectvalidator/pom.xml
+++ b/kernel/kernel-idobjectvalidator/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idvalidator-mispid/pom.xml
+++ b/kernel/kernel-idvalidator-mispid/pom.xml
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idvalidator-prid/pom.xml
+++ b/kernel/kernel-idvalidator-prid/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idvalidator-rid/pom.xml
+++ b/kernel/kernel-idvalidator-rid/pom.xml
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idvalidator-uin/pom.xml
+++ b/kernel/kernel-idvalidator-uin/pom.xml
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-idvalidator-vid/pom.xml
+++ b/kernel/kernel-idvalidator-vid/pom.xml
@@ -47,7 +47,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-licensekeygenerator-misp/pom.xml
+++ b/kernel/kernel-licensekeygenerator-misp/pom.xml
@@ -73,7 +73,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-logger-logback/pom.xml
+++ b/kernel/kernel-logger-logback/pom.xml
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-notification-service/pom.xml
+++ b/kernel/kernel-notification-service/pom.xml
@@ -112,7 +112,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-pdfgenerator/pom.xml
+++ b/kernel/kernel-pdfgenerator/pom.xml
@@ -103,7 +103,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-pinvalidator/pom.xml
+++ b/kernel/kernel-pinvalidator/pom.xml
@@ -60,7 +60,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-pridgenerator-service/pom.xml
+++ b/kernel/kernel-pridgenerator-service/pom.xml
@@ -181,7 +181,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-qrcodegenerator-zxing/pom.xml
+++ b/kernel/kernel-qrcodegenerator-zxing/pom.xml
@@ -49,7 +49,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-ridgenerator-service/pom.xml
+++ b/kernel/kernel-ridgenerator-service/pom.xml
@@ -115,7 +115,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-salt-generator/pom.xml
+++ b/kernel/kernel-salt-generator/pom.xml
@@ -136,7 +136,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-templatemanager-velocity/pom.xml
+++ b/kernel/kernel-templatemanager-velocity/pom.xml
@@ -65,7 +65,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-transliteration-icu4j/pom.xml
+++ b/kernel/kernel-transliteration-icu4j/pom.xml
@@ -69,7 +69,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/kernel-websubclient-api/pom.xml
+++ b/kernel/kernel-websubclient-api/pom.xml
@@ -65,7 +65,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>ossrh</publishingServerId>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -235,7 +235,7 @@
                <plugin>
                   <groupId>org.sonatype.central</groupId>
                   <artifactId>central-publishing-maven-plugin</artifactId>
-                  <version>0.7.0</version>
+                  <version>0.11.0</version>
                   <extensions>true</extensions>
                   <configuration>
                         <publishingServerId>ossrh</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
               <plugin>
                   <groupId>org.sonatype.central</groupId>
                   <artifactId>central-publishing-maven-plugin</artifactId>
-                  <version>0.7.0</version>
+                  <version>0.11.0</version>
                   <extensions>true</extensions>
                   <configuration>
                       <publishingServerId>ossrh</publishingServerId>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Maven publishing tooling across all project modules to version 0.11.0.
  * Standardized publishing configuration throughout the build.
  * No application functionality, public APIs, or runtime behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->